### PR TITLE
feat: Return up to 2 transit candidates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,9 @@ Jorudan uses CloudFront with JavaScript redirect for bot detection. Simple fetch
 ### HTML Parsing
 - Split by `<hr size="1" color="black">` (handle both self-closing and non-self-closing)
 - Line endings: Handle both `\r\n` and `\n` with regex `/\r?\n\r?\n/`
-- Target block: `blocks[TARGET_BLOCK_INDEX]` (index 2) contains transit info
+- Target block: `blocks[TARGET_BLOCK_INDEX]` (index 2) contains all transit routes
+- Route separation: `splitRoutes()` splits by `(?=発着時間：)` lookahead pattern
+- Returns up to `MAX_CANDIDATES` (2) transit candidates
 
 ### Security Measures
 - **ReDoS protection**: `escapeRegExp()` escapes regex special chars in dynamic patterns
@@ -49,10 +51,12 @@ Jorudan uses CloudFront with JavaScript redirect for bot detection. Simple fetch
 - **Structured logging**: JSON format for CloudWatch analysis
 
 ### Response Format
+Returns up to 2 transit candidates:
 ```json
 {
   "transfers": [
-    ["18:49発 → 19:38着(49分)(1回)", "■六本木一丁目\n｜東京メトロ南北線..."]
+    ["18:49発 → 19:38着(49分)(1回)", "■六本木一丁目\n｜東京メトロ南北線..."],
+    ["18:55発 → 19:45着(50分)(2回)", "■六本木一丁目\n｜東京メトロ丸ノ内線..."]
   ]
 }
 ```
@@ -63,7 +67,7 @@ Jorudan uses CloudFront with JavaScript redirect for bot detection. Simple fetch
 |------|-------------|
 | `src/index.mjs` | Lambda handler with cookie flow |
 | `src/lambda_function.py` | Original Python (reference only) |
-| `tests/handler.test.mjs` | Unit tests (16 tests) |
+| `tests/handler.test.mjs` | Unit tests |
 | `tests/e2e.test.mjs` | E2E tests |
 | `template.yml` | SAM template |
 | `Dockerfile` | Lambda container image |

--- a/README.md
+++ b/README.md
@@ -55,13 +55,17 @@ sam deploy
 
 **Endpoint**: `GET /transit`
 
-**Response**:
+**Response** (up to 2 transit candidates):
 ```json
 {
   "transfers": [
     [
       "18:49発 → 19:38着(49分)(1回)",
-      "■六本木一丁目\n｜東京メトロ南北線(赤羽岩淵行)\n｜18:49-18:57［8分］\n｜516円\n◇市ヶ谷\n..."
+      "■六本木一丁目\n｜東京メトロ南北線...\n■つつじヶ丘（東京）"
+    ],
+    [
+      "18:55発 → 19:45着(50分)(2回)",
+      "■六本木一丁目\n｜東京メトロ丸ノ内線...\n■つつじヶ丘（東京）"
     ]
   ]
 }
@@ -75,7 +79,7 @@ src/
 ├── package.json       # Dependencies
 └── lambda_function.py # Original Python (reference)
 tests/
-├── handler.test.mjs   # Unit tests (16 tests)
+├── handler.test.mjs   # Unit tests
 └── e2e.test.mjs       # E2E tests
 Dockerfile             # Lambda container image
 docker-compose.yml     # Local development

--- a/tests/e2e.test.mjs
+++ b/tests/e2e.test.mjs
@@ -19,18 +19,21 @@ describe('E2E Tests', () => {
         // Verify response structure
         assert.ok(Array.isArray(body.transfers), 'transfers should be an array');
         assert.ok(body.transfers.length > 0, 'transfers should not be empty');
+        assert.ok(body.transfers.length <= 2, 'transfers should have at most 2 candidates');
 
-        const [summary, route] = body.transfers[0];
+        // Verify each candidate
+        body.transfers.forEach(([summary, route], index) => {
+          assert.ok(typeof summary === 'string', `candidate ${index} summary should be a string`);
+          assert.ok(summary.length > 0, `candidate ${index} summary should not be empty`);
+          assert.ok(typeof route === 'string', `candidate ${index} route should be a string`);
+        });
 
-        // Verify summary format (time(duration)(transfers))
-        assert.ok(typeof summary === 'string', 'summary should be a string');
-        assert.ok(summary.length > 0, 'summary should not be empty');
-
-        // Verify route exists
-        assert.ok(typeof route === 'string', 'route should be a string');
-
-        console.log('Transit Summary:', summary);
-        console.log('Route:', route);
+        console.log(`Found ${body.transfers.length} transit candidates:`);
+        body.transfers.forEach(([summary, route], index) => {
+          console.log(`\nCandidate ${index + 1}:`);
+          console.log('  Summary:', summary);
+          console.log('  Route:', route.substring(0, 100) + '...');
+        });
       } else {
         // If failed, check error message exists
         assert.ok(body.error, 'Should have error message on failure');

--- a/tests/handler.test.mjs
+++ b/tests/handler.test.mjs
@@ -1,14 +1,45 @@
 import { describe, it, mock } from 'node:test';
 import assert from 'node:assert';
-import { getSummary, getRoute, handler } from '../src/index.mjs';
+import { getSummary, getRoute, splitRoutes, handler } from '../src/index.mjs';
 
 // Mock HTML block similar to Jorudan's response
 const mockBlock = `発着時間：06:30～08:45\r\n所要時間：2時間15分\r\n乗換回数：2回\r\n\r\n六本木一丁目\r\n｜ 　東京メトロ南北線\r\n永田町\r\n｜ 　東京メトロ半蔵門線\r\n渋谷\r\n｜ 　京王井の頭線\r\nつつじヶ丘（東京）`;
+
+// Second mock block for multiple candidates testing
+const mockBlock2 = `発着時間：07:00～09:00\r\n所要時間：2時間\r\n乗換回数：1回\r\n\r\n新宿\r\n｜ 　京王線\r\nつつじヶ丘（東京）`;
+
+// Third mock block for MAX_CANDIDATES testing
+const mockBlock3 = `発着時間：08:00～10:00\r\n所要時間：2時間\r\n乗換回数：0回\r\n\r\n渋谷\r\n｜ 　京王井の頭線\r\n明大前`;
+
+// Combined blocks for multiple candidates
+const mockMultipleBlocks = `${mockBlock}${mockBlock2}`;
+const mockThreeBlocks = `${mockBlock}${mockBlock2}${mockBlock3}`;
 
 // Helper to create mock headers
 function createMockHeaders(data = {}) {
   return {
     get: (key) => data[key.toLowerCase()] || null,
+  };
+}
+
+// Helper to run handler with mocked fetch
+async function runWithMockedFetch(response, testFn) {
+  const mockFetch = mock.fn(async () => response);
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = mockFetch;
+  try {
+    return await testFn();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+// Helper to create a standard successful response
+function createMockResponse(html) {
+  return {
+    ok: true,
+    text: async () => html,
+    headers: createMockHeaders({}),
   };
 }
 
@@ -58,134 +89,148 @@ describe('getRoute', () => {
   });
 });
 
+describe('splitRoutes', () => {
+  it('should split multiple routes correctly', () => {
+    const routes = splitRoutes(mockMultipleBlocks);
+    assert.strictEqual(routes.length, 2, 'Should return 2 routes');
+  });
+
+  it('should return array for single route', () => {
+    const routes = splitRoutes(mockBlock);
+    assert.strictEqual(routes.length, 1, 'Should return 1 route');
+    assert.ok(routes[0].includes('06:30～08:45'), 'Should contain first route data');
+  });
+
+  it('should return empty array for empty string', () => {
+    const routes = splitRoutes('');
+    assert.strictEqual(routes.length, 0, 'Should return empty array');
+  });
+
+  it('should return empty array when no 発着時間 found', () => {
+    const routes = splitRoutes('some random text without routes');
+    assert.strictEqual(routes.length, 0, 'Should return empty array');
+  });
+
+  it('should filter out empty strings', () => {
+    const routes = splitRoutes('   \n  ' + mockBlock);
+    assert.strictEqual(routes.length, 1, 'Should filter whitespace-only entries');
+  });
+});
+
 describe('handler', () => {
-  const validHtml = `block0<hr size="1" color="black" />block1<hr size="1" color="black" />${mockBlock}<hr size="1" color="black" />block3`;
+  // Helper to build HTML with route blocks
+  function buildHtml(routeContent) {
+    return `block0<hr size="1" color="black" />block1<hr size="1" color="black" />${routeContent}<hr size="1" color="black" />block3`;
+  }
+
+  const validHtml = buildHtml(mockBlock);
 
   it('should return statusCode 200 on success', async () => {
-    // Mock fetch that returns valid HTML directly (no redirect)
-    const mockFetch = mock.fn(async () => ({
-      ok: true,
-      text: async () => validHtml,
-      headers: createMockHeaders({}),
-    }));
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = mockFetch;
-
-    try {
+    await runWithMockedFetch(createMockResponse(validHtml), async () => {
       const result = await handler({}, {});
       assert.strictEqual(result.statusCode, 200, 'Should return status 200');
       assert.ok(result.body, 'Should have body');
 
       const body = JSON.parse(result.body);
       assert.ok(Array.isArray(body.transfers), 'Should have transfers array');
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    });
   });
 
   it('should return error on JavaScript redirect (bot detection)', async () => {
     const redirectPage = '<!DOCTYPE html><script>function rdr(){window.location.href="/webuser/set-uuid.cgi?url=/test"}</script>';
 
-    const mockFetch = mock.fn(async () => ({
-      ok: true,
-      text: async () => redirectPage,
-      headers: createMockHeaders({}),
-    }));
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = mockFetch;
-
-    try {
+    await runWithMockedFetch(createMockResponse(redirectPage), async () => {
       const result = await handler({}, {});
       assert.strictEqual(result.statusCode, 500, 'Should return status 500 on bot detection');
 
       const body = JSON.parse(result.body);
-      // Error message is now generic for security
       assert.ok(body.error, 'Should have error message');
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    });
   });
 
   it('should return statusCode 500 on unexpected HTML structure', async () => {
-    const mockFetch = mock.fn(async () => ({
-      ok: true,
-      text: async () => 'only one block',
-      headers: createMockHeaders({}),
-    }));
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = mockFetch;
-
-    try {
+    await runWithMockedFetch(createMockResponse('only one block'), async () => {
       const result = await handler({}, {});
       assert.strictEqual(result.statusCode, 500, 'Should return status 500');
 
       const body = JSON.parse(result.body);
       assert.ok(body.error, 'Should have error message');
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    });
   });
 
   it('should have correct content-type header', async () => {
-    const mockFetch = mock.fn(async () => ({
-      ok: true,
-      text: async () => validHtml,
-      headers: createMockHeaders({}),
-    }));
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = mockFetch;
-
-    try {
+    await runWithMockedFetch(createMockResponse(validHtml), async () => {
       const result = await handler({}, {});
       assert.strictEqual(result.headers['Content-Type'], 'application/json', 'Should have JSON content type');
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    });
   });
 
   it('should reject SSRF attempt via protocol in redirect path', async () => {
-    // Malicious redirect attempting to escape to another domain
     const ssrfRedirectPage = '<!DOCTYPE html><script>function rdr(){window.location.href="//evil.com/steal"}</script>';
 
-    const mockFetch = mock.fn(async () => ({
-      ok: true,
-      text: async () => ssrfRedirectPage,
-      headers: createMockHeaders({}),
-    }));
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = mockFetch;
-
-    try {
+    await runWithMockedFetch(createMockResponse(ssrfRedirectPage), async () => {
       const result = await handler({}, {});
       assert.strictEqual(result.statusCode, 500, 'Should return status 500 on SSRF attempt');
       const body = JSON.parse(result.body);
       assert.ok(body.error, 'Should have error message');
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    });
   });
 
   it('should handle HTTP error status codes', async () => {
-    const mockFetch = mock.fn(async () => ({
+    const errorResponse = {
       ok: false,
       status: 403,
       text: async () => 'Forbidden',
       headers: createMockHeaders({}),
-    }));
+    };
 
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = mockFetch;
-
-    try {
+    await runWithMockedFetch(errorResponse, async () => {
       const result = await handler({}, {});
       assert.strictEqual(result.statusCode, 500, 'Should return status 500 on HTTP error');
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    });
+  });
+
+  it('should return multiple candidates when available', async () => {
+    await runWithMockedFetch(createMockResponse(buildHtml(mockMultipleBlocks)), async () => {
+      const result = await handler({}, {});
+      assert.strictEqual(result.statusCode, 200, 'Should return status 200');
+
+      const body = JSON.parse(result.body);
+      assert.strictEqual(body.transfers.length, 2, 'Should return 2 candidates');
+      assert.ok(body.transfers[0][0].includes('06:30～08:45'), 'First candidate should have first route time');
+      assert.ok(body.transfers[1][0].includes('07:00～09:00'), 'Second candidate should have second route time');
+    });
+  });
+
+  it('should limit candidates to MAX_CANDIDATES (2)', async () => {
+    await runWithMockedFetch(createMockResponse(buildHtml(mockThreeBlocks)), async () => {
+      const result = await handler({}, {});
+      assert.strictEqual(result.statusCode, 200, 'Should return status 200');
+
+      const body = JSON.parse(result.body);
+      assert.strictEqual(body.transfers.length, 2, 'Should return only 2 candidates even when 3 available');
+    });
+  });
+
+  it('should return error when no transit routes found', async () => {
+    await runWithMockedFetch(createMockResponse(buildHtml('no routes here')), async () => {
+      const result = await handler({}, {});
+      assert.strictEqual(result.statusCode, 500, 'Should return status 500 when no routes found');
+
+      const body = JSON.parse(result.body);
+      assert.ok(body.error, 'Should have error message');
+    });
+  });
+
+  it('should filter out malformed route data', async () => {
+    const malformedBlock = `発着時間：\r\n\r\n`;
+
+    await runWithMockedFetch(createMockResponse(buildHtml(malformedBlock)), async () => {
+      const result = await handler({}, {});
+      assert.strictEqual(result.statusCode, 500, 'Should return status 500 for malformed route data');
+
+      const body = JSON.parse(result.body);
+      assert.ok(body.error, 'Should have error message');
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Add `splitRoutes()` function to parse multiple transit routes from Jorudan's HTML response
- Return up to 2 transit candidates instead of 1 (configurable via `MAX_CANDIDATES`)
- Add validation to filter out malformed route data
- Refactor tests with helper functions for cleaner code

## Changes
| File | Description |
|------|-------------|
| `src/index.mjs` | Add `splitRoutes()`, `MAX_CANDIDATES`, malformed data filtering |
| `tests/handler.test.mjs` | Add 9 new tests, refactor with helper functions |
| `tests/e2e.test.mjs` | Update to verify multiple candidates |
| `CLAUDE.md`, `README.md` | Update documentation |

## Test plan
- [x] All 25 unit tests pass (`npm test`)
- [x] E2E test verifies multiple candidates from real Jorudan API
- [x] Docker local verification returns 2 candidates