### PR TITLE
feat: Add SSRF protection for absolute URLs in Location header

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -161,8 +161,15 @@ async function fetchTransitPage(url) {
 
   // Step 3: Follow Location header if present, or extract final URL
   let finalUrl = response2.headers.get('location');
-  if (finalUrl && !finalUrl.startsWith('http')) {
-    finalUrl = safeJoinUrl(JORUDAN_BASE_URL, finalUrl);
+  if (finalUrl) {
+    if (finalUrl.startsWith('http')) {
+      const parsedUrl = new URL(finalUrl);
+      if (parsedUrl.origin !== JORUDAN_BASE_URL) {
+        throw new Error('Invalid redirect: unexpected domain');
+      }
+    } else {
+      finalUrl = safeJoinUrl(JORUDAN_BASE_URL, finalUrl);
+    }
   }
 
   // If no location header, the redirect URL contains the final URL in query param

--- a/template.yml
+++ b/template.yml
@@ -9,7 +9,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri: ./src
-      Description: Lambda Function of Nagatacho To TsuTsujigaoka
+      Description: Lambda Function of Roppongi-itchome To TsuTsujigaoka
       MemorySize: 128
       Timeout: 10
       Handler: index.handler


### PR DESCRIPTION
## Summary

- Fix route description in template.yml (Nagatacho → Roppongi-itchome)
- Add SSRF protection for absolute URLs in Location header to prevent redirect attacks
- Add `runWithSequencedFetch` test helper for multi-step fetch mocking
- Add test case for SSRF attempt via absolute URL in Location header

## Security Enhancement

The previous implementation only validated relative URLs via `safeJoinUrl()`. This PR adds explicit validation for absolute URLs in the Location header:

- Validates that absolute URLs (`http://` or `https://`) must have origin matching `JORUDAN_BASE_URL`
- Throws error for redirects to unexpected domains
- Relative paths continue to use `safeJoinUrl()` for protection

### Edge Cases Handled

| Scenario | Location Header Value | Result |
|----------|----------------------|--------|
| External domain | `https://evil.com/steal` | Rejected |
| Subdomain attack | `https://api.jorudan.co.jp/path` | Rejected |
| Valid HTTPS | `https://www.jorudan.co.jp/path` | Accepted |
| Relative path | `/norikae/result` | Accepted |

## Test Plan

- [x] Unit tests pass (26 tests)
- [x] E2E test passes
- [x] Docker container rebuild and verification via Playwright
- [x] Security review passed (no vulnerabilities found)

Closes #4, #5, #7