### PR TITLE
fix: Add --resolve-s3 flag to SAM deploy

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -42,7 +42,7 @@ jobs:
         run: sam build
       - name: SAM Deploy
         if: ${{ github.event.inputs.dry-run != 'true' }}
-        run: sam deploy --no-confirm-changeset --no-fail-on-empty-changeset
+        run: sam deploy --no-confirm-changeset --no-fail-on-empty-changeset --resolve-s3
       - name: Health Check
         if: ${{ github.event.inputs.dry-run != 'true' }}
         run: |

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -5,3 +5,4 @@ stack_name = "transitmikanmarusan"
 region = "ap-northeast-1"
 confirm_changeset = false
 capabilities = "CAPABILITY_IAM"
+resolve_s3 = true


### PR DESCRIPTION
## Summary
- Add `--resolve-s3` flag to `sam deploy` command in `deploy-production.yml`
- Add `resolve_s3 = true` to `samconfig.toml` for local deployments

## Problem
Deploy to Production workflow (Run #21176414129) failed with:
```
Error: Unable to upload artifact transitmikanmarusan referenced by CodeUri parameter of transitmikanmarusan resource.
S3 Bucket not specified
```

## Solution
The `--resolve-s3` flag allows SAM to automatically create and manage a default S3 bucket (`aws-sam-cli-managed-default-*`) for Lambda code uploads.

## Test plan
- [ ] Merge this PR to main
- [ ] Run "Deploy to Production" workflow with `confirmation: deploy`
- [ ] Verify SAM Deploy step completes successfully
- [ ] Verify Health Check step passes