### PR TITLE
refactor: Rename Lambda LogicalId for clearer function naming

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -13,7 +13,7 @@ Globals:
       AllowMethods: "'GET,OPTIONS'"
 
 Resources:
-  transitmikanmarusan:
+  TransitFunction:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri: ./src
@@ -41,7 +41,7 @@ Resources:
                 - logs:CreateLogStream
                 - logs:PutLogEvents
               Resource:
-                - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/transitmikanmarusan:*'
+                - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${AWS::StackName}-TransitFunction-*:*'
       RecursiveLoop: Terminate
       SnapStart:
         ApplyOn: None
@@ -68,6 +68,6 @@ Outputs:
 
   TransitFunctionArn:
     Description: Lambda function ARN
-    Value: !GetAtt transitmikanmarusan.Arn
+    Value: !GetAtt TransitFunction.Arn
     Export:
       Name: !Sub '${AWS::StackName}-lambda-arn'


### PR DESCRIPTION
## Summary
- Rename Lambda LogicalId from `transitmikanmarusan` to `TransitFunction` to eliminate redundant naming pattern (`transitmikanmarusan-transitmikanmarusan-*`)
- Update CloudWatch log pattern to use dynamic `${AWS::StackName}-TransitFunction-*` reference
- Update Outputs reference to use new LogicalId

## Result
- Before: `transitmikanmarusan-transitmikanmarusan-CSnZkrRWA4lt`
- After: `transitmikanmarusan-TransitFunction-{suffix}`

## Test plan
- [x] Unit tests passed (31/31)
- [x] Lint passed
- [x] Docker environment tested (`/status` and `/transit` endpoints)
- [x] Playwright browser verification completed
- [x] Code review passed

## Note
LogicalId change will cause CloudFormation to replace the Lambda function (create new, delete old). API Gateway endpoints are maintained within the same stack.