### PR TITLE
refactor: Reduce API Gateway triggers from 4 to 2

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Health Check - API
         if: ${{ github.event.inputs.dry-run != 'true' }}
         run: |
-          curl -f "${{ steps.stack-outputs.outputs.api_endpoint }}/status" || exit 1
+          curl -f "${{ steps.stack-outputs.outputs.api_endpoint }}/api/status" || exit 1
 
       - name: Health Check - Frontend
         if: ${{ github.event.inputs.dry-run != 'true' }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ CloudFront + S3 (Frontend) → API Gateway → Lambda → Jorudan
 - **Backend Runtime**: Node.js 22 (ESM)
 - **Frontend**: React 19 + TypeScript + Vite
 - **Entry point**: `src/index.mjs` → `handler(event, context)`
-- **API Gateway trigger**: GET `/transit`, GET `/status`, GET `/api/transit`, GET `/api/status`
+- **API Gateway trigger**: GET `/api/transit`, GET `/api/status`
 - **Region**: ap-northeast-1
 
 ## Build and Deploy

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ sam deploy
 
 ## API Specification
 
-**Endpoint**: `GET /transit`
+**Endpoint**: `GET /api/transit` (CloudFront) or `GET /transit` (dev server)
 
 **Response** (up to 2 transit candidates):
 ```json
@@ -80,14 +80,20 @@ sam deploy
 ```
 src/
 ├── index.mjs          # Lambda handler
+├── dev-server.mjs     # Development server
 ├── package.json       # Dependencies
 └── lambda_function.py # Original Python (reference)
 tests/
 ├── handler.test.mjs   # Unit tests
 └── e2e.test.mjs       # E2E tests
+frontend/              # React frontend
+├── src/               # Source code
+├── tests/             # Tests
+└── package.json       # Dependencies
+.github/workflows/     # CI/CD
 Dockerfile             # Lambda container image
 docker-compose.yml     # Local development
-template.yml           # SAM template
+template.yml           # SAM template (Lambda + CloudFront + S3)
 ```
 
 ## Notes

--- a/template.yml
+++ b/template.yml
@@ -48,19 +48,9 @@ Resources:
         Transit:
           Type: Api
           Properties:
-            Path: /transit
-            Method: GET
-        TransitWithApiPrefix:
-          Type: Api
-          Properties:
             Path: /api/transit
             Method: GET
         Status:
-          Type: Api
-          Properties:
-            Path: /status
-            Method: GET
-        StatusWithApiPrefix:
           Type: Api
           Properties:
             Path: /api/status


### PR DESCRIPTION
## Summary
- Remove `/transit` and `/status` endpoints from API Gateway
- Keep only `/api/transit` and `/api/status` endpoints (used by CloudFront)
- Update deploy-production.yml health check path to `/api/status`
- Update documentation (CLAUDE.md, README.md)

## Background
CloudFront only routes `/api/*` paths to API Gateway. The non-prefixed endpoints (`/transit`, `/status`) were unused in production and caused unnecessary API Gateway triggers.

## Changes
| File | Change |
|------|--------|
| `template.yml` | Reduced events from 4 to 2 |
| `deploy-production.yml` | Updated health check path |
| `CLAUDE.md` | Updated API Gateway trigger docs |
| `README.md` | Updated API spec and project structure |

## Test plan
- [x] All backend tests pass (31 tests)
- [x] Lint passes
- [x] Code review completed
- [ ] Verify after deploy: CloudFront endpoints work (`/api/transit`, `/api/status`)
- [ ] Verify after deploy: Only 2 API Gateway triggers in AWS Console