### PR TITLE
feat: Display full transfer details including intermediate stations

### DIFF
--- a/frontend/src/components/RouteDetail.module.css
+++ b/frontend/src/components/RouteDetail.module.css
@@ -15,6 +15,12 @@
   min-height: 40px;
 }
 
+.stopIntermediate {
+  display: flex;
+  gap: var(--space-3);
+  min-height: 32px;
+}
+
 .marker {
   display: flex;
   flex-direction: column;
@@ -23,13 +29,25 @@
   flex-shrink: 0;
 }
 
-.dot {
+.dotTerminal {
   width: 8px;
   height: 8px;
   border-radius: 50%;
   background-color: var(--accent-blue);
   flex-shrink: 0;
   margin-top: 4px;
+  box-sizing: border-box;
+}
+
+.dotTransfer {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: transparent;
+  border: 2px solid var(--accent-blue);
+  flex-shrink: 0;
+  margin-top: 4px;
+  box-sizing: border-box;
 }
 
 .line {
@@ -46,15 +64,30 @@
   padding-bottom: var(--space-2);
 }
 
+.contentIntermediate {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding-bottom: var(--space-1);
+}
+
 .station {
   color: var(--text-primary);
   font-size: 13px;
   font-weight: 500;
 }
 
+.stationIntermediate {
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 500;
+}
+
 .lineName {
   color: var(--text-tertiary);
   font-size: 11px;
+  padding-left: var(--space-2);
+  border-left: 2px solid var(--border-secondary);
 }
 
 .rawRoute {

--- a/frontend/src/components/RouteDetail.tsx
+++ b/frontend/src/components/RouteDetail.tsx
@@ -16,23 +16,31 @@ export function RouteDetail({ route }: RouteDetailProps) {
     )
   }
 
+  const isTerminal = (index: number) =>
+    index === 0 || index === stations.length - 1
+
   return (
     <div className={styles.container}>
       <div className={styles.timeline}>
-        {stations.map((item, index) => (
-          <div key={index} className={styles.stop}>
-            <div className={styles.marker}>
-              <div className={styles.dot} />
-              {index < stations.length - 1 && <div className={styles.line} />}
+        {stations.map((item, index) => {
+          const terminal = isTerminal(index)
+          return (
+            <div key={index} className={terminal ? styles.stop : styles.stopIntermediate}>
+              <div className={styles.marker}>
+                <div className={terminal ? styles.dotTerminal : styles.dotTransfer} />
+                {index < stations.length - 1 && <div className={styles.line} />}
+              </div>
+              <div className={terminal ? styles.content : styles.contentIntermediate}>
+                <span className={terminal ? styles.station : styles.stationIntermediate}>
+                  {item.station}
+                </span>
+                {item.line && (
+                  <span className={styles.lineName}>{item.line}</span>
+                )}
+              </div>
             </div>
-            <div className={styles.content}>
-              <span className={styles.station}>{item.station}</span>
-              {item.line && (
-                <span className={styles.lineName}>{item.line}</span>
-              )}
-            </div>
-          </div>
-        ))}
+          )
+        })}
       </div>
     </div>
   )

--- a/frontend/src/types/transit.ts
+++ b/frontend/src/types/transit.ts
@@ -50,8 +50,8 @@ export function parseRoute(route: string): { station: string; line: string | nul
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]
-    if (line.startsWith('■')) {
-      const station = line.replace(/^■/, '').trim()
+    if (line.startsWith('■') || line.startsWith('◇')) {
+      const station = line.replace(/^[■◇]/, '').trim()
       const nextLine = lines[i + 1]
       const lineName = nextLine?.startsWith('｜') ? nextLine.replace(/^｜/, '').trim() : null
       result.push({ station, line: lineName })

--- a/frontend/tests/transit.test.ts
+++ b/frontend/tests/transit.test.ts
@@ -84,4 +84,19 @@ describe('parseRoute', () => {
     expect(result[0].station).toBe('駅A')
     expect(result[0].line).toBeNull()
   })
+
+  it('should parse route with intermediate transfer stations (◇)', () => {
+    const route = '■六本木一丁目 1番線発\n｜東京メトロ南北線(浦和美園行) 3.1km\n◇永田町 3番線着・1番線発 ［乗換4分+待ち4分］\n｜東京メトロ半蔵門線(中央林間行) 5.7km\n◇渋谷 1番線着・1番線発 ［乗換6分+待ち4分］\n｜京王井の頭線(吉祥寺行) 12.5km\n■つつじヶ丘（東京） 1・2番線着'
+    const result = parseRoute(route)
+
+    expect(result).toHaveLength(4)
+    expect(result[0].station).toBe('六本木一丁目 1番線発')
+    expect(result[0].line).toBe('東京メトロ南北線(浦和美園行) 3.1km')
+    expect(result[1].station).toBe('永田町 3番線着・1番線発 ［乗換4分+待ち4分］')
+    expect(result[1].line).toBe('東京メトロ半蔵門線(中央林間行) 5.7km')
+    expect(result[2].station).toBe('渋谷 1番線着・1番線発 ［乗換6分+待ち4分］')
+    expect(result[2].line).toBe('京王井の頭線(吉祥寺行) 12.5km')
+    expect(result[3].station).toBe('つつじヶ丘（東京） 1・2番線着')
+    expect(result[3].line).toBeNull()
+  })
 })

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -55,9 +55,17 @@ export function getRoute(block) {
   const route = block.trim().split(/\r?\n\r?\n/)[1] || '';
 
   return route
-    .replace(/｜ 　/g, '｜')           // Remove extra spacing after separator
-    .replace(/\s+$/gm, '')             // Remove trailing spaces from each line
-    .replace(/\s{2,}(.*)$/gm, '');     // Remove lines with 2+ leading spaces
+    .replace(/｜ 　/g, '｜')
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(line => {
+      if (line.startsWith('■') || line.startsWith('◇')) return true;
+      if (!line.startsWith('｜')) return false;
+      const content = line.slice(1).trim();
+      // Keep only line names (filter out times, fares, and arrows)
+      return content !== '' && !/^[\d↓↑]/.test(content);
+    })
+    .join('\n');
 }
 
 /**

--- a/tests/handler.test.mjs
+++ b/tests/handler.test.mjs
@@ -2,14 +2,14 @@ import { describe, it, mock } from 'node:test';
 import assert from 'node:assert';
 import { getSummary, getRoute, splitRoutes, handler } from '../src/index.mjs';
 
-// Mock HTML block similar to Jorudan's response
-const mockBlock = `発着時間：06:30～08:45\r\n所要時間：2時間15分\r\n乗換回数：2回\r\n\r\n六本木一丁目\r\n｜ 　東京メトロ南北線\r\n永田町\r\n｜ 　東京メトロ半蔵門線\r\n渋谷\r\n｜ 　京王井の頭線\r\nつつじヶ丘（東京）`;
+// Mock HTML block matching real Jorudan format (■ for terminal, ◇ for transfer stations)
+const mockBlock = `発着時間：06:30～08:45\r\n所要時間：2時間15分\r\n乗換回数：2回\r\n\r\n■六本木一丁目    1番線発\r\n｜ 　東京メトロ南北線(浦和美園行)   3.1km\r\n｜06:30-06:36［6分］\r\n｜178円\r\n◇永田町    3番線着・1番線発 ［乗換4分+待ち4分］\r\n｜ 　東京メトロ半蔵門線(中央林間行)   5.7km\r\n｜06:44-06:53［9分］\r\n｜ ↓\r\n◇渋谷    1番線着・1番線発 ［乗換6分+待ち4分］\r\n｜ 　京王井の頭線(吉祥寺行)   12.5km\r\n｜07:03-07:20［17分］\r\n｜230円\r\n■つつじヶ丘（東京）    1・2番線着`;
 
 // Second mock block for multiple candidates testing
-const mockBlock2 = `発着時間：07:00～09:00\r\n所要時間：2時間\r\n乗換回数：1回\r\n\r\n新宿\r\n｜ 　京王線\r\nつつじヶ丘（東京）`;
+const mockBlock2 = `発着時間：07:00～09:00\r\n所要時間：2時間\r\n乗換回数：1回\r\n\r\n■新宿    1番線発\r\n｜ 　京王線(京王八王子行)   12.5km\r\n｜07:00-07:20［20分］\r\n｜230円\r\n■つつじヶ丘（東京）    1・2番線着`;
 
 // Third mock block for MAX_CANDIDATES testing
-const mockBlock3 = `発着時間：08:00～10:00\r\n所要時間：2時間\r\n乗換回数：0回\r\n\r\n渋谷\r\n｜ 　京王井の頭線\r\n明大前`;
+const mockBlock3 = `発着時間：08:00～10:00\r\n所要時間：2時間\r\n乗換回数：0回\r\n\r\n■渋谷    1番線発\r\n｜ 　京王井の頭線(吉祥寺行)   4.9km\r\n｜08:00-08:10［10分］\r\n■明大前    1番線着`;
 
 // Combined blocks for multiple candidates
 const mockMultipleBlocks = `${mockBlock}${mockBlock2}`;
@@ -88,14 +88,39 @@ describe('getSummary', () => {
 });
 
 describe('getRoute', () => {
-  it('should extract route information', () => {
+  it('should extract terminal stations', () => {
     const route = getRoute(mockBlock);
-    assert.ok(route.includes('六本木一丁目'), 'Should contain start station');
-    assert.ok(route.includes('つつじヶ丘（東京）'), 'Should contain end station');
+    assert.ok(route.includes('■六本木一丁目'), 'Should contain start station');
+    assert.ok(route.includes('■つつじヶ丘（東京）'), 'Should contain end station');
+  });
+
+  it('should preserve intermediate transfer stations (◇)', () => {
+    const route = getRoute(mockBlock);
+    assert.ok(route.includes('◇永田町'), 'Should contain transfer station 永田町');
+    assert.ok(route.includes('◇渋谷'), 'Should contain transfer station 渋谷');
+  });
+
+  it('should keep line names and filter out times, fares, arrows', () => {
+    const route = getRoute(mockBlock);
+    // Line names should be kept
+    assert.ok(route.includes('東京メトロ南北線'), 'Should contain line name');
+    assert.ok(route.includes('東京メトロ半蔵門線'), 'Should contain line name');
+    assert.ok(route.includes('京王井の頭線'), 'Should contain line name');
+    // Times, fares, arrows should be filtered out
+    assert.ok(!route.includes('06:30-06:36'), 'Should not contain time info');
+    assert.ok(!route.includes('178円'), 'Should not contain fare info');
+    assert.ok(!route.includes('↓'), 'Should not contain arrow');
+  });
+
+  it('should produce correct number of lines for multi-transfer route', () => {
+    const route = getRoute(mockBlock);
+    const lines = route.split('\n');
+    // 4 stations (■x2 + ◇x2) + 3 line names = 7 lines
+    assert.strictEqual(lines.length, 7, 'Should have 7 lines (4 stations + 3 line names)');
   });
 
   it('should remove extra spaces from separator', () => {
-    const blockWithSpaces = `summary\r\n\r\n六本木一丁目\r\n｜ 　test`;
+    const blockWithSpaces = `summary\r\n\r\n■六本木一丁目\r\n｜ 　test`;
     const route = getRoute(blockWithSpaces);
     assert.ok(!route.includes('｜ 　'), 'Should not contain "｜ 　"');
   });


### PR DESCRIPTION
## Summary
- Backend `getRoute()` を修正し、Jorudanの `◇` マーカー付き中間乗換駅を保持するようにした
- 時刻・運賃・矢印の `｜` 行をフィルタし、路線名のみ残すホワイトリスト方式に変更
- Frontend `parseRoute()` が `◇` マーカーを駅として認識するよう修正
- `RouteDetail` コンポーネントで出発/到着駅(filled dot)と中間乗換駅(hollow dot)を視覚的に区別

## Test plan
- [x] Backend unit tests (32 pass) — 中間駅保持・フィルタ検証
- [x] Frontend unit tests (9 pass) — 4駅マルチ乗換パース検証
- [x] Both lint checks pass
- [x] npm audit: 0 vulnerabilities (backend + frontend)
- [ ] Docker環境で `http://localhost:3000` を開き、2回/3回乗り換えカードで全駅表示を目視確認

## Related Issues
- Closes #19
- Follow-up: #20 (マーカー型伝播), #21 (parseRoute index skip)