### PR TITLE
feat(skill): add branch creation step to x-fix-vulnerability

### DIFF
--- a/.claude/skills/x-fix-vulnerability/SKILL.md
+++ b/.claude/skills/x-fix-vulnerability/SKILL.md
@@ -24,27 +24,46 @@ Detect and fix npm audit vulnerabilities, matching the CI security check (`npm a
 2. Run `npm audit --audit-level=high --prefix frontend`
 3. If no high/critical vulnerabilities found, report clean and stop
 
+### Branch
+
+4. Check working tree: `git status --porcelain`. If dirty, stop and report "Commit or stash changes before running this skill"
+5. Check current branch (`git branch --show-current`) and act accordingly:
+
+   | Current branch | Action |
+   |---------------|--------|
+   | `main` | Proceed to step 6 |
+   | `fix/npm-audit-vulnerabilities` | Skip branch creation, proceed to step 7 |
+   | Other | STOP — ask user to switch to main or abort |
+
+6. Create and switch to development branch:
+   a. Check if branch already exists: `git branch --list fix/npm-audit-vulnerabilities`
+   b. If exists: STOP — report that the branch already exists and ask user to delete it (`git branch -d fix/npm-audit-vulnerabilities`) or switch to it
+   c. If not exists: `git checkout -b fix/npm-audit-vulnerabilities`
+
 ### Phase 2: Fix
 
-4. Run `npm audit fix` at root (never use `--force`)
-5. Run `npm audit fix --prefix frontend` (never use `--force`)
-6. Re-run `npm audit --audit-level=high` at both locations to check remaining issues
-7. For vulnerabilities that `npm audit fix` cannot resolve, add `overrides` to the relevant `package.json` and run `npm install` to apply
+7. Run `npm audit fix` at root (never use `--force`)
+8. Run `npm audit fix --prefix frontend` (never use `--force`)
+9. Re-run `npm audit --audit-level=high` at both locations to check remaining issues
+10. For vulnerabilities that `npm audit fix` cannot resolve, add `overrides` to the relevant `package.json` and run `npm install` to apply
 
 ### Phase 3: Verify
 
-8. Run `npm test` (backend tests)
-9. Run `npm run --prefix frontend test -- --run` (frontend tests)
-10. Run `npm run lint` (backend lint)
-11. Run `npm run --prefix frontend lint` (frontend lint)
-12. If tests fail after fixes, revert and report the incompatibility
+11. Run `npm test` (backend tests)
+12. Run `npm run --prefix frontend test -- --run` (frontend tests)
+13. Run `npm run lint` (backend lint)
+14. Run `npm run --prefix frontend lint` (frontend lint)
+15. If tests fail after fixes, revert and report the incompatibility
 
 ### Phase 4: Report
 
-13. Output a summary:
+16. Output a summary:
 
 ```
 ## Vulnerability Fix Report
+
+### Branch
+- Branch: `fix/npm-audit-vulnerabilities`
 
 ### Before
 - Root: X vulnerabilities

--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,7 @@ vite.config.ts.timestamp-*
 # Plan files (Claude Code temporary working documents)
 .plans/*
 !.plans/.gitkeep
+frontend/.plans/
+
+# macOS metadata
+.DS_Store

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3964,9 +3964,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

The x-fix-vulnerability skill previously had no branch creation step, relying solely on the global rule in `03-development-mode.md`. This PR adds an explicit Branch section between the Audit and Fix phases so that vulnerability fixes are always isolated on a dedicated `fix/npm-audit-vulnerabilities` branch.

## Changes

- Add Branch section (steps 4-6) with three guards:
  - Step 4: Dirty working tree check (`git status --porcelain`)
  - Step 5: 3-way branch logic — proceed on `main`, skip creation on target branch, STOP on other branches
  - Step 6: Branch creation with existence check to prevent `git checkout -b` failure
- Renumber all subsequent steps (old 4-13 → new 7-16)
- Add branch name to the Phase 4 report template