### PR TITLE
feat(skill): add x-pentest penetration testing skill

### DIFF
--- a/.claude/skills/x-pentest/SKILL.md
+++ b/.claude/skills/x-pentest/SKILL.md
@@ -1,0 +1,776 @@
+---
+name: x-pentest
+description: End-to-end penetration test for the transit Lambda backend and React frontend — static analysis, live pentest against dev-server.mjs, plan file generation, and optional GitHub issue creation with native sub-issues. Use when running a comprehensive pentest or after major backend/frontend changes.
+---
+
+# Penetration Test
+
+Orchestrate a complete, repeatable security penetration test for the Lambda transit backend (`src/index.mjs`) and React frontend (`frontend/`): static analysis of the attack surface, live dynamic testing against a running dev server, plan file generation with classified findings, and optional GitHub issue creation using a parent Epic with native sub-issues.
+
+## Context
+
+This skill produces the following artifacts on every run:
+
+- A plan file under `.plans/<slug>.md` with classified findings and remediation priorities
+- A reusable Node.js pentest script written to `/tmp/pentest-<slug>.js`
+- Optionally: a parent GitHub Epic issue with child sub-issues per PR-sized remediation group, linked via the GitHub native `addSubIssue` GraphQL mutation
+
+### When to use
+
+- After major changes to `src/index.mjs` (handler logic, SSRF protections, HTML parsing)
+- After dependency upgrades in root or frontend `package.json`
+- Before a production deployment via SAM
+- Periodically as a security hygiene check
+- After changes to `template.yml` (IAM, CORS, CloudFront configuration)
+
+### What this skill does NOT do
+
+- Does not apply any fixes automatically (use `/x-fix-vulnerability` for npm audit fixes or `/x-fix-issue` for specific issue resolution)
+- Does not test AWS infrastructure in production (IAM deep audit, S3 bucket policies, CloudFront live headers)
+- Does not test the Vite frontend dev server (only tests the backend dev server at port 8000)
+- Does not produce compliance mapping (SOC2, PCI-DSS)
+- Does not run performance or load testing
+
+### Hardcoded project assumptions
+
+This skill is tuned for this project. If you adapt it to another codebase, review and adjust:
+
+| Assumption | Value | Where |
+|------------|-------|-------|
+| Backend entry point | `src/index.mjs` | all phases |
+| Dev server file | `src/dev-server.mjs` | Phase 0, 3 |
+| Stack | Node.js 22 ESM, raw Lambda handler (no Express, no middleware) | Phase 1 agent prompts |
+| Dev server command | `node src/dev-server.mjs` | Phase 3 |
+| Health endpoint (dev) | `/status` (NOT `/api/status`) | Phase 3 probe |
+| Transit endpoint (dev) | `/transit` (NOT `/api/transit`) | Phase 3 tests |
+| Frontend directory | `frontend/` | Phase 1 Agent B |
+| SAM template | `template.yml` | Phase 1 Agent C |
+| Plan destination | `.plans/<slug>.md` | Phase 4 |
+| Pentest script | `/tmp/pentest-<slug>.js` | Phase 3 |
+| GitHub repo | auto-detected via `git remote get-url origin` | Phase 6 |
+| Port | 8000 | Phase 0, 3 |
+| External dependency | `https://www.jorudan.co.jp` (outbound HTTP during /transit) | Phase 3 |
+| Response contract source of truth | `src/index.mjs` (NOT CLAUDE.md) | Phase 3 baseline test |
+
+### Dev server vs production behavior
+
+The dev server (`src/dev-server.mjs`) and the production deployment (API Gateway + Lambda) behave differently in several ways. The skill must distinguish between them:
+
+| Behavior | Dev server | Production |
+|----------|-----------|------------|
+| Path prefix | `/status`, `/transit` | `/api/status`, `/api/transit` (normalized by `normalizePath`) |
+| HTTP methods | Only GET (others return 404) | API Gateway may handle OPTIONS for CORS preflight |
+| Security headers | None (raw `http.createServer`) | CloudFront SecurityHeadersPolicy adds HSTS, X-Frame-Options, etc. |
+| CORS | Set in Lambda response headers (`Access-Control-Allow-Origin: *`) | Set at both API Gateway level and Lambda response |
+
+Phase 3 tests that find missing security headers or limited method support on the dev server should be classified as "dev-server limitation, covered in production" — not as findings.
+
+## Prerequisites
+
+Verify before starting. Stop and report the missing item if any check fails.
+
+1. Port 8000 must be free (`lsof -i :8000` returns nothing)
+2. `node --version` must be >= 22
+3. Current working directory must be the repo root
+4. `ls frontend/node_modules` must exist (run `npm ci --prefix frontend` if missing)
+
+Note: `gh auth status` is NOT checked here. It is checked only if the user opts into Phase 6 (GitHub issue creation).
+
+## Execution
+
+Execute these phases in order. Do not skip phases. User interaction gates (Phase 2, 5, and optionally 6) are mandatory dialogue points and must not be automated away.
+
+### Phase 0: Intake and Setup
+
+1. Verify all prerequisites above. If any fail, report the failure and stop.
+2. If an argument is provided on invocation, treat it as the plan file slug (without `.md` extension). If omitted, generate a random three-word slug matching the pattern `<adjective>-<gerund/adjective>-<noun>` (e.g., `gleaming-prowling-fox`).
+3. Set `$SLUG` to the chosen slug and `$PLAN_FILE` to `.plans/${SLUG}.md`.
+4. If `$PLAN_FILE` already exists, stop and report: "Plan file already exists. Provide a different slug or delete the existing file."
+
+### Phase 1: Static Analysis (Parallel Exploration)
+
+Launch exactly three `Explore` subagents in parallel using a single message with three `Agent` tool calls. Each agent has a specialized scope.
+
+#### Agent A — Backend Handler: SSRF, Cookie Flow, HTML Parsing
+
+Focus: outbound HTTP safety, redirect following, cookie extraction, HTML parsing of untrusted Jorudan content, regex safety, error handling, information disclosure in error responses.
+
+Target paths:
+- `src/index.mjs` (the entire backend — all security-critical code is here)
+- `src/dev-server.mjs`
+- `tests/handler.test.mjs`
+- `tests/e2e.test.mjs`
+
+Required output: a findings table with `file:line` references. For each finding, flag whether it needs Phase 3 live confirmation. Specifically:
+1. Trace `fetchTransitPage()` and map all URLs that outbound `fetch()` can reach. Verify `safeJoinUrl()` covers all bypass vectors (protocol-relative, data: URIs, javascript: URIs, backslash, `@` in path, path traversal).
+2. Assess `extractRedirectUrl()` — could a crafted Jorudan response inject an arbitrary URL via the `window.location.href="..."` regex?
+3. Assess `extractCookies()` — could malformed Set-Cookie headers cause issues?
+4. Assess HTML parsing (`split(/<hr size="1" color="black"\s*\/?>/i)`) — can this produce content that reaches the frontend unsanitized?
+5. Assess error messages in `createJsonResponse(500, ...)` — do they leak internal state?
+6. Check `dev-server.mjs` error handling — confirm no stack trace leakage in HTTP responses.
+7. Verify `safeJoinUrl` as a checkpoint: confirm that metadata endpoint IPs (169.254.169.254) cannot be reached because all paths are joined to the Jorudan base URL.
+
+#### Agent B — Frontend: XSS, Data Rendering, API Consumption
+
+Focus: how API response data reaches the DOM, XSS via transit data, React rendering safety, build configuration.
+
+Target paths:
+- `frontend/src/hooks/useTransit.ts`
+- `frontend/src/types/transit.ts`
+- `frontend/src/components/TransitCard.tsx`
+- `frontend/src/components/RouteDetail.tsx`
+- `frontend/src/components/StatusIndicator.tsx`
+- `frontend/src/App.tsx`
+- `frontend/vite.config.ts`
+- `frontend/index.html`
+- `frontend/package.json`
+
+Required output:
+1. Trace data flow from `fetch('/api/transit')` through parsing functions into JSX rendering. Identify any path where API data could be rendered as raw HTML (e.g., `dangerouslySetInnerHTML`).
+2. Verify no `dangerouslySetInnerHTML` exists anywhere in the frontend.
+3. Check Vite proxy configuration for SSRF potential (dev-only risk).
+4. Check `vite.config.ts` build settings — confirm `sourcemap: false` in production.
+5. Assess `isValidTransitResponse()` type guard robustness.
+6. Test `parseSummary()` and `parseRoute()` regex patterns for ReDoS potential.
+7. Flag known false positives (React's default JSX escaping prevents XSS).
+
+#### Agent C — Infrastructure, Dependencies, CI
+
+Focus: SAM template, Docker configuration, CI workflows, npm dependencies, CORS configuration.
+
+Target paths:
+- `template.yml`
+- `samconfig.toml`
+- `Dockerfile`
+- `docker-compose.yml`
+- `package.json` (root)
+- `frontend/package.json`
+- `.github/workflows/ci.yml`
+- `.github/workflows/deploy-production.yml`
+- `eslint.config.mjs`
+
+Required output:
+1. CORS analysis: `template.yml` has `AllowOrigin: "'*'"` — assess risk given the API has no authentication and serves public transit data.
+2. CloudFront SecurityHeadersPolicy — verify which headers are covered in production.
+3. Check for hardcoded AWS account IDs, API Gateway IDs, or production URLs in committed files.
+4. Check Docker images for unnecessary packages, root user execution, or exposed debug ports.
+5. Run `npm audit --audit-level=high` analysis on root and frontend `package.json`.
+6. List safe patterns explicitly ruled out: no database, no user input, no authentication, no file system writes, no `eval`/`Function`/`child_process`.
+
+### Phase 2: Threat Model and Classification
+
+1. Consolidate findings from the three agents into a single master table with columns: ID, finding, file:line, proposed severity, classification.
+2. For each finding, assign a classification:
+   - `Critical` / `High` / `Medium` / `Low`
+   - `Known false positive` — e.g., React auto-escaping handles XSS
+   - `Requires Phase 3 live confirmation`
+   - `Intentional configuration` — e.g., CORS `*` on a public transit API with no auth
+3. Note safe patterns explicitly ruled out by Agent C.
+
+**Pre-classifications for this project** (override only if evidence contradicts):
+
+| Finding | Classification | Reason |
+|---------|---------------|--------|
+| `Access-Control-Allow-Origin: *` | Intentional configuration | Public read-only transit API, no auth, no user data |
+| User-Agent spoofing in BROWSER_HEADERS | Intentional configuration | Required for Jorudan bot detection bypass |
+| No API authentication | Intentional configuration | Public transit data, no mutations |
+| Missing security headers on dev server | Dev-server limitation | CloudFront SecurityHeadersPolicy covers production |
+| Dev server returns 404 for non-GET | Dev-server limitation | API Gateway handles method routing in production |
+
+**User interaction gate #1**: present the classified table via `AskUserQuestion` with these choices:
+- Accept classification and proceed to Phase 3
+- Re-classify specific findings (user will provide details)
+- Add a finding that was missed
+- Abort
+
+If the user re-classifies or adds findings, update the master table and re-ask until accepted.
+
+### Phase 3: Live Penetration Testing
+
+1. Start the API dev server in the background:
+   ```
+   node src/dev-server.mjs
+   ```
+   Use `run_in_background: true` on the `Bash` tool call. Capture the task ID as `$SERVER_TASK_ID`.
+
+2. Wait for the server to be ready. Do not use `sleep` — instead, write a probe script at `/tmp/probe-${SLUG}.js`:
+   ```javascript
+   const http = require('http')
+   const tryOnce = () => new Promise((resolve) => {
+     const req = http.get('http://localhost:8000/status', (res) => {
+       resolve(res.statusCode === 200)
+     })
+     req.on('error', () => resolve(false))
+   })
+   ;(async () => {
+     for (let i = 0; i < 20; i++) {
+       if (await tryOnce()) { console.log('ready'); return }
+       await new Promise(r => setTimeout(r, 100))
+     }
+     console.error('not ready after 2s')
+     process.exit(1)
+   })()
+   ```
+   Run `node /tmp/probe-${SLUG}.js`. If it fails, read the server background log, report the error, stop the server, and abort the phase.
+
+3. Write the pentest script at `/tmp/pentest-${SLUG}.js` using **Template A** (see Templates section below).
+
+4. Execute the pentest script:
+   ```
+   RESULTS_FILE=/tmp/pentest-results-${SLUG}.txt node /tmp/pentest-${SLUG}.js
+   ```
+   Capture stdout. The script also writes to the results file.
+
+5. Read the server background log to inspect:
+   - Whether any error response contains stack traces or internal file paths
+   - Whether the server remained stable throughout the test
+
+6. Run npm audit separately:
+   ```
+   npm audit --audit-level=high
+   npm audit --audit-level=high --prefix frontend
+   ```
+
+7. Stop the background server via `TaskStop` with `$SERVER_TASK_ID`.
+
+8. Record all results in memory for Phase 4.
+
+**Important**: The `/transit` endpoint makes real outbound HTTP calls to `https://www.jorudan.co.jp`. Tests hitting this endpoint will take 3-10 seconds and may timeout if Jorudan is unreachable. If `/transit` returns 500 due to Jorudan being down, classify as "external service unavailable" — not as a vulnerability in this application.
+
+### Phase 4: Plan File Generation
+
+Write the plan file at `$PLAN_FILE` using **Template B** (see Templates section). Populate every section with real data from Phases 1, 2, and 3. Do not leave placeholders.
+
+Required sections (in order):
+1. Context — date, commit hash (from `git rev-parse --short HEAD`), what prompted the pentest
+2. Phase 1 Findings — static analysis summary with severity table per agent
+3. Phase 2 Threat Model — classified table from the Phase 2 output
+4. Phase 3 Live Test Results — row per test with expected vs actual
+5. Confirmed Vulnerabilities — grouped by severity
+6. Re-evaluated Non-vulnerabilities — with reasoning and re-evaluation triggers
+7. Remediation Priorities — Step A immediate / Step B sprint / Step C next sprint
+8. Verification Procedure — how to confirm fixes
+9. Raw Execution Results — trimmed pentest script output
+
+### Phase 5: User Review Gate
+
+1. Display the plan file path and a short summary (count of vulnerabilities by severity, count of re-evaluated items, count of proposed remediation steps).
+2. **User interaction gate #2**: present via `AskUserQuestion` with these choices:
+   - Create GitHub Issues (proceed to Phase 6)
+   - Stop here (keep plan file only, skip Phase 6)
+   - Request specific revisions (user will provide details)
+3. If the user requests revisions, edit the plan file and re-ask until the user chooses one of the first two options.
+4. If the user chooses to stop, write a summary report and exit the skill.
+
+### Phase 6: GitHub Issue Creation (Optional)
+
+This phase runs only if the user chose "Create GitHub Issues" in Phase 5.
+
+1. Check `gh auth status`. If not authenticated, stop and report: "Run `gh auth login` to authenticate, then re-run `/x-pentest <slug>`."
+2. Propose an issue grouping strategy based on the findings. Default proposal: **parent Epic plus sub-issues grouped by PR boundary** (group findings that touch the same file or subsystem).
+3. **User interaction gate #3**: present via `AskUserQuestion` with these choices:
+   - Accept the default grouping
+   - Use a single bundled issue for everything
+   - Create one issue per finding (no grouping)
+   - Adjust a specific group (user will provide details)
+4. Create the parent Epic via `gh issue create` using **Template C** (parent Epic body). Title format: `chore : {description} tracking`. Save the returned URL and extract the issue number.
+5. Fetch the parent's node ID:
+   ```
+   gh api graphql -f query='query { repository(owner: "$OWNER", name: "$REPO") { issue(number: $N) { id } } }'
+   ```
+   Owner and repo come from `git remote get-url origin`.
+6. For each grouped remediation, create a child issue via `gh issue create` using **Template D** (sub-issue body). Title format: `{type} : {English title}` where type is `fix`, `refactor`, `chore`, or `docs`. Save each returned URL and number.
+7. Fetch each child's node ID the same way.
+8. Link each child to the parent using **Template E** (GraphQL addSubIssue mutation).
+9. Verify linkage by querying `subIssues` on the parent. Assert the count matches the number of child issues created.
+10. Edit the plan file to append a section "Created Issues" with the parent and child URLs.
+
+All issue titles and bodies MUST be in English. No emojis anywhere in issue content.
+
+### Phase 7: Summary Report
+
+Output a Markdown summary to the user containing:
+
+- Plan file path
+- If Phase 6 was executed: parent Epic URL and child issue URLs
+- If Phase 6 was skipped: note that issues were not created, suggest manual creation
+- Suggested next actions:
+  - `/x-fix-vulnerability` if any npm audit findings were flagged
+  - `/x-fix-issue <child number>` if issues were created
+  - Re-run `/x-pentest` after fixes merge
+
+Clean up: optionally remove `/tmp/pentest-${SLUG}.js`, `/tmp/pentest-results-${SLUG}.txt`, and `/tmp/probe-${SLUG}.js` (but keep them if the user wants to re-run tests manually).
+
+## Templates
+
+### Template A — Pentest Script (Node.js)
+
+Write this script to `/tmp/pentest-${SLUG}.js` during Phase 3. It uses only the Node.js `http` module (no curl, no fetch). Tests are split into high-signal (handler response surface) and low-signal (dev-server-specific) sections.
+
+```javascript
+#!/usr/bin/env node
+/**
+ * Penetration Test Script for lambda-function-transit
+ * Tests against localhost:8000 (dev-server.mjs)
+ */
+
+const http = require('http')
+const fs = require('fs')
+
+const BASE = 'http://localhost:8000'
+const RESULTS_FILE = process.env.RESULTS_FILE || '/tmp/pentest-results.txt'
+const results = []
+
+function request (options, body = null) {
+  return new Promise((resolve, reject) => {
+    const req = http.request(options, (res) => {
+      let data = ''
+      res.on('data', (c) => { data += c })
+      res.on('end', () => resolve({ status: res.statusCode, headers: res.headers, body: data }))
+    })
+    req.on('error', reject)
+    req.setTimeout(15000, () => { req.destroy(new Error('timeout')) })
+    if (body) req.write(body)
+    req.end()
+  })
+}
+
+function get (path, headers = {}) {
+  const url = new URL(BASE + path)
+  return request({
+    hostname: url.hostname,
+    port: url.port,
+    path: url.pathname + url.search,
+    method: 'GET',
+    headers
+  })
+}
+
+function methodReq (m, path, headers = {}) {
+  const url = new URL(BASE + path)
+  return request({
+    hostname: url.hostname,
+    port: url.port,
+    path: url.pathname + url.search,
+    method: m,
+    headers
+  })
+}
+
+function header (headers, name) {
+  const k = Object.keys(headers).find(x => x.toLowerCase() === name.toLowerCase())
+  return k ? headers[k] : '(absent)'
+}
+
+function log (section, label, data) {
+  const line = `[${section}] ${label}: ${data}`
+  console.log(line)
+  results.push(line)
+}
+
+async function main () {
+  // === HIGH-SIGNAL TESTS (handler response surface) ===
+
+  // 1. Baseline response shape
+  console.log('\n=== 1. Baseline Response Shape ===')
+  {
+    const r = await get('/status')
+    log('1', 'GET /status status', r.status)
+    log('1', 'GET /status Content-Type', header(r.headers, 'content-type'))
+    try {
+      const body = JSON.parse(r.body)
+      log('1', 'GET /status has .status', String('status' in body))
+      log('1', 'GET /status has .timestamp', String('timestamp' in body))
+    } catch (e) {
+      log('1', 'GET /status JSON parse', 'FAILED: ' + e.message)
+    }
+  }
+  {
+    const r = await get('/transit')
+    log('1', 'GET /transit status', r.status)
+    log('1', 'GET /transit Content-Type', header(r.headers, 'content-type'))
+    try {
+      const body = JSON.parse(r.body)
+      if (r.status === 200) {
+        log('1', 'GET /transit has .routes', String('routes' in body))
+        log('1', 'GET /transit routes is array', String(Array.isArray(body.routes)))
+        if (body.routes && body.routes.length > 0) {
+          const first = body.routes[0]
+          log('1', 'route[0] has .origin', String('origin' in first))
+          log('1', 'route[0] has .destination', String('destination' in first))
+          log('1', 'route[0] has .transfers', String('transfers' in first))
+        }
+      } else {
+        log('1', 'GET /transit error body', r.body.slice(0, 200))
+      }
+    } catch (e) {
+      log('1', 'GET /transit JSON parse', 'FAILED: ' + e.message)
+    }
+  }
+
+  // 2. Error disclosure
+  console.log('\n=== 2. Error Disclosure ===')
+  {
+    const r = await get('/not-a-real-path')
+    log('2', 'GET /not-a-real-path status', r.status)
+    const hasStack = r.body.includes('at ') && r.body.includes('.mjs')
+    log('2', '404 body contains stack trace', String(hasStack))
+    const hasSrcPath = r.body.includes('src/') || r.body.includes('/app/')
+    log('2', '404 body contains internal path', String(hasSrcPath))
+    log('2', '404 body preview', r.body.slice(0, 200))
+  }
+  {
+    try {
+      const longPath = '/' + 'A'.repeat(8000)
+      const r = await get(longPath)
+      log('2', 'GET 8KB path status', r.status)
+      const hasStack = r.body.includes('at ') && r.body.includes('.mjs')
+      log('2', '8KB path body contains stack trace', String(hasStack))
+    } catch (e) {
+      log('2', 'GET 8KB path', 'error=' + e.message)
+    }
+  }
+  {
+    const r = await get('/transit')
+    if (r.status === 500) {
+      const hasStack = r.body.includes('at ') && (r.body.includes('.mjs') || r.body.includes('.js:'))
+      log('2', '/transit 500 contains stack trace', String(hasStack))
+      const hasInternalUrl = r.body.includes('jorudan.co.jp') || r.body.includes('www.')
+      log('2', '/transit 500 leaks internal URLs', String(hasInternalUrl))
+      log('2', '/transit 500 body preview', r.body.slice(0, 300))
+    } else {
+      log('2', '/transit returned 200 (Jorudan reachable)', 'skipping error disclosure check')
+    }
+  }
+
+  // 3. CORS headers
+  console.log('\n=== 3. CORS Headers ===')
+  {
+    const r = await get('/status', { Origin: 'https://evil.example.com' })
+    log('3', 'ACAO on /status', header(r.headers, 'access-control-allow-origin'))
+  }
+  {
+    const r = await get('/transit', { Origin: 'https://evil.example.com' })
+    log('3', 'ACAO on /transit', header(r.headers, 'access-control-allow-origin'))
+  }
+
+  // 4. Response Content-Type
+  console.log('\n=== 4. Response Content-Type ===')
+  {
+    const r = await get('/status')
+    log('4', '/status Content-Type', header(r.headers, 'content-type'))
+  }
+  {
+    const r = await get('/not-a-real-path')
+    log('4', '404 Content-Type', header(r.headers, 'content-type'))
+  }
+
+  // 5. Response header leakage
+  console.log('\n=== 5. Response Header Leakage ===')
+  {
+    const r = await get('/status')
+    log('5', 'X-Powered-By', header(r.headers, 'x-powered-by'))
+    log('5', 'Server', header(r.headers, 'server'))
+  }
+
+  // === LOW-SIGNAL TESTS (dev-server-specific) ===
+
+  // 7. HTTP methods (dev-server limitation)
+  console.log('\n=== 7. HTTP Methods (dev-server) ===')
+  for (const m of ['POST', 'PUT', 'DELETE', 'PATCH', 'TRACE', 'HEAD']) {
+    try {
+      const r = await methodReq(m, '/transit')
+      log('7', m + ' /transit', 'status=' + r.status)
+    } catch (e) {
+      log('7', m + ' /transit', 'error=' + e.message)
+    }
+  }
+
+  // 8. Security headers (absent on dev-server, covered by CloudFront in production)
+  console.log('\n=== 8. Security Headers (dev-server) ===')
+  {
+    const r = await get('/status')
+    const hdrNames = [
+      'strict-transport-security', 'content-security-policy',
+      'x-frame-options', 'x-content-type-options', 'x-dns-prefetch-control',
+      'referrer-policy', 'cross-origin-opener-policy', 'cross-origin-resource-policy'
+    ]
+    for (const h of hdrNames) log('8', h, header(r.headers, h))
+  }
+
+  // 9. Unknown paths (dev-server)
+  console.log('\n=== 9. Unknown Paths (dev-server) ===')
+  {
+    const r = await get('/admin')
+    log('9', 'GET /admin status', r.status)
+    const reflected = r.body.includes('admin')
+    log('9', '/admin path reflected in body', String(reflected))
+  }
+  {
+    const r = await get('/../etc/passwd')
+    log('9', 'GET /../etc/passwd status', r.status)
+    log('9', 'path traversal body preview', r.body.slice(0, 100))
+  }
+  {
+    const r = await get('/' + encodeURIComponent('<script>alert(1)</script>'))
+    log('9', 'GET /<script> status', r.status)
+    const reflected = r.body.includes('<script>')
+    log('9', 'script tag reflected in body', String(reflected))
+  }
+
+  console.log('\n=== END ===')
+  fs.writeFileSync(RESULTS_FILE, results.join('\n'))
+  console.log('Results saved to ' + RESULTS_FILE)
+}
+
+main().catch((e) => { console.error('FATAL:', e); process.exit(1) })
+```
+
+Note: npm audit (test 6) is run separately via Bash during Phase 3, not inside this script.
+
+### Template B — Plan File Skeleton
+
+```markdown
+# Penetration Test: {SLUG}
+
+## Context
+
+- Date: {ISO date}
+- Commit: {git short SHA}
+- Target: Backend (`src/index.mjs`, `src/dev-server.mjs`) + Frontend (`frontend/src/`)
+- Trigger: {why this pentest was run}
+- Scope: {which phases were executed}
+
+## Phase 1 Findings (Static Analysis)
+
+### Agent A — Backend Handler: SSRF, Cookie Flow, HTML Parsing
+
+| ID | Finding | file:line | Proposed severity |
+|----|---------|-----------|-------------------|
+| A1 | ... | ... | ... |
+
+### Agent B — Frontend: XSS, Data Rendering, API Consumption
+
+| ID | Finding | file:line | Proposed severity |
+|----|---------|-----------|-------------------|
+| B1 | ... | ... | ... |
+
+### Agent C — Infrastructure, Dependencies, CI
+
+| ID | Finding | file:line | Proposed severity |
+|----|---------|-----------|-------------------|
+| C1 | ... | ... | ... |
+
+### Safe patterns ruled out
+
+- No SQL injection surface (no database)
+- No command injection (no child_process, exec, or eval)
+- No file system writes (read-only Lambda function)
+- No user-controllable input (hardcoded origins/destinations)
+- No authentication/authorization surface (public API)
+
+## Phase 2 Threat Model (Classified)
+
+| ID | Finding | Severity | Classification | Next step |
+|----|---------|----------|----------------|-----------|
+| ... | ... | ... | ... | ... |
+
+## Phase 3 Live Test Results
+
+### High-signal tests
+
+| # | Test | Expected | Actual | Result |
+|---|------|----------|--------|--------|
+| 1 | Baseline /status response shape | 200 + JSON | ... | OK/FAIL |
+| 1 | Baseline /transit response shape | 200 + JSON with routes array | ... | OK/FAIL |
+| 2 | Error disclosure on 404 | No stack traces | ... | OK/FAIL |
+| 2 | Error disclosure on /transit 500 | No internal URLs | ... | OK/FAIL |
+| 3 | CORS headers | ACAO: * present | ... | OK/INTENTIONAL |
+| 4 | Content-Type on all responses | application/json | ... | OK/FAIL |
+| 5 | X-Powered-By absent | (absent) | ... | OK/FAIL |
+| 6 | npm audit root | No high/critical | ... | OK/FAIL |
+| 6 | npm audit frontend | No high/critical | ... | OK/FAIL |
+
+### Low-signal tests (dev-server limitations)
+
+| # | Test | Expected | Actual | Notes |
+|---|------|----------|--------|-------|
+| 7 | POST /transit | 404 | ... | Dev-server only handles GET |
+| 8 | HSTS header | (absent) | ... | CloudFront covers in production |
+| 9 | Path reflection in 404 | No reflection | ... | ... |
+
+## Confirmed Vulnerabilities
+
+### Critical / High
+
+| ID | Finding | Evidence |
+|----|---------|----------|
+| ... | ... | Test X / static analysis |
+
+### Medium
+
+| ID | Finding | Evidence |
+|----|---------|----------|
+
+### Low / Informational
+
+| ID | Finding | Evidence |
+|----|---------|----------|
+
+## Re-evaluated Non-vulnerabilities
+
+| ID | Original classification | Final classification | Reasoning | Re-evaluation triggers |
+|----|------------------------|---------------------|-----------|------------------------|
+| ... | ... | Intentional configuration | ... | When X changes, re-evaluate |
+
+## Remediation Priorities
+
+### Step A (Immediate)
+
+- {grouped remediation}
+
+### Step B (Current Sprint)
+
+- {grouped remediation}
+
+### Step C (Next Sprint)
+
+- {grouped remediation}
+
+## Verification Procedure
+
+After fixes are applied, re-run `/x-pentest` and confirm the previously-confirmed vulnerabilities no longer appear in Phase 3 test results.
+
+## Raw Execution Results
+
+{trimmed output from /tmp/pentest-results-{SLUG}.txt}
+
+## Created Issues (filled in after Phase 6, if executed)
+
+- Parent Epic: #{N} {URL}
+- Sub-issues:
+  - #{N} {URL}
+  - ...
+```
+
+### Template C — Parent Epic Issue Body
+
+```markdown
+## Goal
+
+Track all security findings from the penetration test conducted on {DATE} against the transit Lambda backend and React frontend, and coordinate their remediation via sub-issues.
+
+## Your Task
+
+Complete all sub-issues linked to this parent. The work is organized into {N} independent PR-sized tasks:
+
+{numbered list of sub-issue titles}
+
+## Context
+
+A full penetration test was performed against the local dev server (`node src/dev-server.mjs` at http://localhost:8000) and complemented with static analysis of the Lambda handler (`src/index.mjs`), React frontend (`frontend/src/`), SAM template, and CI configuration.
+
+The full findings and remediation plan are documented in `{PLAN_FILE}`.
+
+### Items excluded from this tracking
+
+{list any items classified as intentional configuration or dev-server limitations}
+
+### Low-priority backlog (not tracked as sub-issues)
+
+{list any low-severity items handled in backlog}
+
+## Warning
+
+- Sub-issues must all be completed before closing this parent issue.
+- Each sub-issue PR should cross-reference the relevant section of `{PLAN_FILE}`.
+- Do not change architectural decisions documented as "Re-evaluated Non-vulnerabilities" in the plan file without re-running this pentest.
+```
+
+### Template D — Sub-issue Body (per finding group)
+
+```markdown
+## Goal
+
+{one-sentence goal — what this issue fixes and why}
+
+## Your Task
+
+1. {specific action with file path and line numbers}
+2. {specific action}
+3. {verification step}
+4. Add or update tests in {test location}
+
+## Context
+
+{what the penetration test found, with reference to plan file section and test number}
+
+Full details are in `{PLAN_FILE}` under "Confirmed Vulnerabilities" or the relevant phase section.
+
+### Evidence
+
+{test result, log output, or static analysis finding that confirms this issue}
+
+## Warning
+
+- {edge cases and constraints}
+- Parent issue: #{PARENT_NUMBER}
+```
+
+### Template E — GraphQL Sub-issue Linking Commands
+
+```bash
+# Get repo node ID (one-time per run)
+gh api graphql -f query='query { repository(owner: "OWNER", name: "REPO") { id name } }'
+
+# Get a specific issue node ID
+gh api graphql -f query='query { repository(owner: "OWNER", name: "REPO") { issue(number: N) { id number title } } }'
+
+# Link a child issue to a parent issue
+gh api graphql \
+  -f query='mutation($p: ID!, $c: ID!) { addSubIssue(input: {issueId: $p, subIssueId: $c}) { issue { number } subIssue { number title } } }' \
+  -f p=PARENT_NODE_ID \
+  -f c=CHILD_NODE_ID
+
+# Verify parent has the expected sub-issues
+gh api graphql -f query='query { repository(owner: "OWNER", name: "REPO") { issue(number: PARENT_N) { number title subIssues(first: 20) { totalCount nodes { number title state } } } } }'
+```
+
+## User Interaction Gates
+
+| Gate | When | Purpose |
+|------|------|---------|
+| #1 | End of Phase 2 | Confirm threat model classification before spending time on Phase 3 |
+| #2 | End of Phase 5 | Approve plan file and decide whether to create GitHub issues |
+| #3 | Start of Phase 6 | Confirm issue grouping strategy before creating GitHub issues (only if user opted in) |
+
+Each gate uses `AskUserQuestion` with 2-4 choices. Always include an option to adjust or abort.
+
+## Important Rules
+
+- Never use curl during Phase 3 — use Node.js `http` module instead.
+- Always stop the background dev server in Phase 3, even on error. Use `TaskStop` with the captured task ID.
+- Issue titles and bodies MUST be in English. No emojis anywhere in GitHub output.
+- Use the format `{type} : {title}` for issue titles where type is `fix`, `refactor`, `chore`, or `docs`.
+- Never close the parent Epic automatically when all child issues close. The user decides when the tracking is done.
+- The `/transit` endpoint makes real outbound HTTP calls to Jorudan. Tests hitting this endpoint will take 3-10 seconds per request. If Jorudan is unreachable, classify as "external service unavailable" not as a vulnerability.
+- The dev server only handles GET on `/status` and `/transit`. All other paths return 404, all other methods return 404. This is the intentional design of `dev-server.mjs` — do not report it as a finding.
+- Path normalization (`/api/*` prefix stripping) only exists in the Lambda handler, not in the dev server. Tests must use `/status` and `/transit` (no `/api/` prefix) when testing against the dev server.
+- Use `src/index.mjs` as the source of truth for response contracts, not CLAUDE.md (CLAUDE.md may be outdated).
+- If the user re-classifies a finding as "Intentional configuration", record the re-evaluation triggers verbatim in the plan file so future runs recognize the decision.
+- Do not delete `.plans/<slug>.md` after the skill completes. It is the audit trail.
+- If any phase fails irrecoverably, stop the background server and report the failure; do not silently skip phases.
+
+## False Positive Registry
+
+These findings are expected for this project and should be classified as intentional, not flagged as vulnerabilities:
+
+| Finding | Reason |
+|---------|--------|
+| `Access-Control-Allow-Origin: *` | Public read-only transit API, no auth, no user-specific data |
+| User-Agent spoofing (Chrome 120) | Required for Jorudan bot detection bypass — core design pattern |
+| No API authentication | Public transit data, no sessions, no mutations, no PII |
+| Cookie handling for Jorudan | First-party session cookies for Jorudan only, not user-facing |
+| Hardcoded station names in source | Public transit information, not sensitive data |
+| Missing security headers on dev server | CloudFront SecurityHeadersPolicy covers production |
+| 404 for non-GET methods on dev server | API Gateway handles method routing in production |


### PR DESCRIPTION
## Summary

Add a project-specific penetration testing skill (`/x-pentest`) that automates security analysis for both the Lambda backend and React frontend. The skill adapts the proven 7-phase structure from the kanji-grade project's `x-api-pentest`, tailored to this project's unique architecture: a raw Lambda handler with outbound HTTP requests to Jorudan and a React 19 frontend.

## Changes

- Add `.claude/skills/x-pentest/SKILL.md` with full 7-phase execution model
- Phase 1: 3 parallel static analysis agents (Backend SSRF/HTML parsing, Frontend XSS/rendering, Infrastructure/Dependencies/CI)
- Phase 2: Threat classification with user interaction gate and pre-classified false positive registry
- Phase 3: Live pentest via `node src/dev-server.mjs` with Node.js test script (9 test sections split into high-signal and low-signal)
- Phase 4-5: Plan file generation and user review gate
- Phase 6 (optional): GitHub Issue creation with Epic + sub-issues via GraphQL
- Phase 7: Summary report with next action recommendations
- Includes all 5 templates (pentest script, plan file skeleton, parent Epic, sub-issue, GraphQL linking)
- Dev-server vs production behavior distinction documented throughout
- False positive registry for project-specific intentional configurations (CORS *, no auth, etc.)