### PR TITLE
fix(handler): add URL scheme validation in extractRedirectUrl

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -92,13 +92,20 @@ const BROWSER_HEADERS = {
 };
 
 /**
- * Extract redirect URL from JavaScript redirect page
+ * Extract redirect URL from JavaScript redirect page.
+ * Only single-leading-slash relative paths are allowed; absolute URLs and
+ * non-HTTP schemes (data:, javascript:, ftp:, file:, ...) return null so the
+ * caller treats them as "no redirect" instead of feeding them into
+ * safeJoinUrl(), which throws on `://`.
  * @param {string} body - HTML body containing JS redirect
- * @returns {string|null} Redirect URL or null
+ * @returns {string|null} Redirect path (relative) or null
  */
-function extractRedirectUrl(body) {
+export function extractRedirectUrl(body) {
   const match = body.match(/window\.location\.href="([^"]+)"/);
-  return match ? match[1] : null;
+  if (!match) return null;
+  const candidate = match[1].trim();
+  if (!/^\/(?!\/)/.test(candidate)) return null;
+  return candidate;
 }
 
 /**

--- a/tests/handler.test.mjs
+++ b/tests/handler.test.mjs
@@ -1,6 +1,6 @@
 import { describe, it, mock } from 'node:test';
 import assert from 'node:assert';
-import { getSummary, getRoute, splitRoutes, handler } from '../src/index.mjs';
+import { getSummary, getRoute, splitRoutes, handler, extractRedirectUrl } from '../src/index.mjs';
 
 // Mock HTML block matching real Jorudan format (■ for terminal, ◇ for transfer stations)
 const mockBlock = `発着時間：06:30～08:45\r\n所要時間：2時間15分\r\n乗換回数：2回\r\n\r\n■六本木一丁目    1番線発\r\n｜ 　東京メトロ南北線(浦和美園行)   3.1km\r\n｜06:30-06:36［6分］\r\n｜178円\r\n◇永田町    3番線着・1番線発 ［乗換4分+待ち4分］\r\n｜ 　東京メトロ半蔵門線(中央林間行)   5.7km\r\n｜06:44-06:53［9分］\r\n｜ ↓\r\n◇渋谷    1番線着・1番線発 ［乗換6分+待ち4分］\r\n｜ 　京王井の頭線(吉祥寺行)   12.5km\r\n｜07:03-07:20［17分］\r\n｜230円\r\n■つつじヶ丘（東京）    1・2番線着`;
@@ -156,6 +156,67 @@ describe('splitRoutes', () => {
   it('should filter out empty strings', () => {
     const routes = splitRoutes('   \n  ' + mockBlock);
     assert.strictEqual(routes.length, 1, 'Should filter whitespace-only entries');
+  });
+});
+
+describe('extractRedirectUrl scheme validation', () => {
+  function bodyWith(href) {
+    return `<html><script>window.location.href="${href}"</script></html>`;
+  }
+
+  it('should accept a single-leading-slash relative path', () => {
+    const result = extractRedirectUrl(bodyWith('/webuser/set-uuid.cgi?url=https%3A%2F%2Fwww.jorudan.co.jp%2Fnorikae%2Fcgi%2Fnori.cgi'));
+    assert.strictEqual(result, '/webuser/set-uuid.cgi?url=https%3A%2F%2Fwww.jorudan.co.jp%2Fnorikae%2Fcgi%2Fnori.cgi');
+  });
+
+  it('should accept a relative path with query string', () => {
+    const result = extractRedirectUrl(bodyWith('/path/with/?query=v&other=v'));
+    assert.strictEqual(result, '/path/with/?query=v&other=v');
+  });
+
+  it('should reject absolute https:// URLs (downstream safeJoinUrl would throw)', () => {
+    const result = extractRedirectUrl(bodyWith('https://www.jorudan.co.jp/norikae/'));
+    assert.strictEqual(result, null);
+  });
+
+  it('should reject data: URIs', () => {
+    const result = extractRedirectUrl(bodyWith('data:text/html,<script>alert(1)</script>'));
+    assert.strictEqual(result, null);
+  });
+
+  it('should reject javascript: URIs', () => {
+    const result = extractRedirectUrl(bodyWith('javascript:alert(1)'));
+    assert.strictEqual(result, null);
+  });
+
+  it('should reject mixed-case JavaScript: URIs', () => {
+    const result = extractRedirectUrl(bodyWith('JavaScript:alert(1)'));
+    assert.strictEqual(result, null);
+  });
+
+  it('should reject ftp:// URIs', () => {
+    const result = extractRedirectUrl(bodyWith('ftp://attacker.example/'));
+    assert.strictEqual(result, null);
+  });
+
+  it('should reject file:// URIs', () => {
+    const result = extractRedirectUrl(bodyWith('file:///etc/passwd'));
+    assert.strictEqual(result, null);
+  });
+
+  it('should reject javascript: URIs even with leading whitespace (after trim)', () => {
+    const result = extractRedirectUrl(bodyWith('  javascript:alert(1)'));
+    assert.strictEqual(result, null);
+  });
+
+  it('should reject protocol-relative // URIs', () => {
+    const result = extractRedirectUrl(bodyWith('//attacker.example/path'));
+    assert.strictEqual(result, null);
+  });
+
+  it('should return null when window.location.href is missing', () => {
+    const result = extractRedirectUrl('<html>no redirect here</html>');
+    assert.strictEqual(result, null);
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #30 — defense-in-depth for pentest findings **A1 / A2** in `.plans/crimson-weaving-falcon.md`.

`extractRedirectUrl()` previously returned any URL captured from Jorudan's bot-detection `window.location.href="..."` redirect. A compromised upstream could emit `data:` or `javascript:` URIs, which would not be blocked by `safeJoinUrl()` (it only filters `//` and `://`).

This PR tightens the function with a strict path-only allowlist:

- **Allowed**: single-leading-slash relative paths (e.g., `/webuser/set-uuid.cgi?url=...`) — the only shape Jorudan actually emits.
- **Rejected** (returns `null`): `data:`, `javascript:`, `JavaScript:` (case-insensitive), `ftp:`, `file:`, protocol-relative `//attacker/`, leading-whitespace bypass attempts, absolute `https://...` (downstream `safeJoinUrl` would throw on `://` anyway), and missing `window.location.href`.
- Trim before scheme test.
- Export the function so unit tests can call it directly.

The existing "no redirect path" branch (src/index.mjs:152) handles `null` cleanly without throwing.

## Why allowlist not blacklist

OWASP/Snyk 2026 standard: a denylist will miss `vbscript:`, `gopher:`, `blob:`, etc. Path-only allowlist is the smallest viable safe shape and matches actual production behavior.

## Test plan

- [x] `npm test` (root) — **46 pass / 0 fail** (was 35; +11 new under `describe('extractRedirectUrl scheme validation')`)
- [x] `npm run lint` (root) — clean
- [x] `npm audit --audit-level=high` (root) — `found 0 vulnerabilities`
- [x] `cd frontend && npm audit --audit-level=high` — exit 0 (1 moderate postcss only, below high gate)
- [x] **Browser verification via Playwright MCP** (replaces npx playwright — Playwright is not a frontend devDep): launched `docker-compose up api-dev frontend-dev`, navigated to http://localhost:3000/, snapshot showed the full UI rendered with live Jorudan transit data (10:55 → 11:48 53分 2回, route detail 六本木一丁目 → 四ッ谷 → 新宿 → つつじヶ丘) and "Connected" status. **Console: 0 errors, 0 warnings**.

## Files

- `src/index.mjs` — `extractRedirectUrl()` strict allowlist + export
- `tests/handler.test.mjs` — `describe('extractRedirectUrl scheme validation')` with 11 cases

## Conflict notes

This PR touches `src/index.mjs` ~line 100 only. Subsequent PRs (#29 template.yml; #31 src/index.mjs:228 + template.yml; #32 frontend + src/index.mjs JSON_HEADERS) edit disjoint regions — no expected conflict.