### PR TITLE
chore(api): remove unused Authorization in CORS and add API throttling

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -232,7 +232,7 @@ async function fetchTransitPage(url) {
 const JSON_HEADERS = {
   'Content-Type': 'application/json',
   'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'Content-Type,Authorization',
+  'Access-Control-Allow-Headers': 'Content-Type',
   'Access-Control-Allow-Methods': 'GET,OPTIONS',
 };
 

--- a/template.yml
+++ b/template.yml
@@ -9,6 +9,11 @@ Globals:
       AllowOrigin: "'*'"
       AllowHeaders: "'Content-Type'"
       AllowMethods: "'GET,OPTIONS'"
+    MethodSettings:
+      - ResourcePath: '/*'
+        HttpMethod: '*'
+        ThrottlingBurstLimit: 100
+        ThrottlingRateLimit: 50
 
 Resources:
   # Lambda Function

--- a/tests/handler.test.mjs
+++ b/tests/handler.test.mjs
@@ -413,3 +413,24 @@ describe('/status endpoint', () => {
     assert.strictEqual(body.status, 'ok', 'Should have status ok');
   });
 });
+
+describe('CORS headers', () => {
+  it('should advertise only Content-Type in Access-Control-Allow-Headers', async () => {
+    const result = await handler({ path: '/status' }, {});
+    assert.strictEqual(
+      result.headers['Access-Control-Allow-Headers'],
+      'Content-Type',
+      'Allow-Headers should not include Authorization since no auth is implemented'
+    );
+  });
+
+  it('should set wildcard Access-Control-Allow-Origin', async () => {
+    const result = await handler({ path: '/status' }, {});
+    assert.strictEqual(result.headers['Access-Control-Allow-Origin'], '*');
+  });
+
+  it('should allow only GET and OPTIONS methods', async () => {
+    const result = await handler({ path: '/status' }, {});
+    assert.strictEqual(result.headers['Access-Control-Allow-Methods'], 'GET,OPTIONS');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #31 — pentest findings **C4** (misleading CORS) and **C5** (no API throttle) in `.plans/crimson-weaving-falcon.md`.

### C4 — Authorization removed from Allow-Headers

`JSON_HEADERS['Access-Control-Allow-Headers']` advertised `Content-Type,Authorization`, but no authorization mechanism exists in this Lambda. The header gave API consumers the false impression auth was supported. Verified with `grep -R Authorization frontend/src/` → no matches; nothing was actually sending the header.

After change: `Access-Control-Allow-Headers: 'Content-Type'`.

### C5 — Stage-level throttle added

Added `Globals.Api.MethodSettings` to `template.yml`:

```yaml
MethodSettings:
  - ResourcePath: '/*'
    HttpMethod: '*'
    ThrottlingBurstLimit: 100
    ThrottlingRateLimit: 50
```

50 RPS / 100 burst chosen because: it matches the issue's suggested values, fits the personal traffic profile (~0.03 rps current), gives ~50× CI smoke-test headroom (~1 rps), and protects the 128 MB / 10 s Lambda from runaway invocations. UsagePlan was rejected (would force API keys on a public unauthenticated API).

## Test plan

- [x] `npm test` (root) — **49 pass / 0 fail** (was 46; +3 new under `describe('CORS headers')`)
- [x] `npm run lint` (root) — clean
- [x] `npm audit --audit-level=high` (root) — `found 0 vulnerabilities`
- [x] `cd frontend && npm audit --audit-level=high` — exit 0 (1 moderate postcss only, below high gate)
- [x] **`sam validate --lint`** (via Docker) — `template.yml is a valid SAM Template`
- [x] **Browser verification via Playwright MCP:** docker-compose up api-dev frontend-dev → restart api-dev to load updated source → fetch `/api/status` from page context → response carries `Access-Control-Allow-Headers: Content-Type` (Authorization removed). UI rendered live transit data — **0 console errors / 0 warnings**.

## Files

- `src/index.mjs` — `JSON_HEADERS['Access-Control-Allow-Headers']` value `'Content-Type,Authorization'` → `'Content-Type'`
- `template.yml` — `Globals.Api.MethodSettings` block added (4 lines)
- `tests/handler.test.mjs` — 3 new CORS-header assertions

## Conflict notes

This PR touches `src/index.mjs:235` inside `JSON_HEADERS` (lines 232-237). **PR #4 (Issue #32)** will insert `'X-Content-Type-Options': 'nosniff'` into the same block — order #31 → #32 makes #32 a 1-line insertion above the line this PR changed. Trivial rebase expected.