### PR TITLE
fix(frontend): strengthen type guard, fix ReDoS, add nosniff

### DIFF
--- a/frontend/src/hooks/useTransit.ts
+++ b/frontend/src/hooks/useTransit.ts
@@ -3,13 +3,23 @@ import { MultiTransitState, TransitResponse, parseTransitResponse } from '../typ
 
 const API_BASE = '/api'
 
-function isValidTransitResponse(data: unknown): data is TransitResponse {
-  return (
-    typeof data === 'object' &&
-    data !== null &&
-    'routes' in data &&
-    Array.isArray((data as TransitResponse).routes)
-  )
+export function isValidTransitResponse(data: unknown): data is TransitResponse {
+  if (typeof data !== 'object' || data === null || !('routes' in data)) return false
+  const routes = (data as TransitResponse).routes
+  if (!Array.isArray(routes)) return false
+  return routes.every((r) => {
+    if (r === null || typeof r !== 'object') return false
+    const route = r as { origin: unknown; destination: unknown; transfers: unknown }
+    if (typeof route.origin !== 'string' || typeof route.destination !== 'string') return false
+    if (!Array.isArray(route.transfers)) return false
+    return route.transfers.every(
+      (t) =>
+        Array.isArray(t) &&
+        t.length === 2 &&
+        typeof t[0] === 'string' &&
+        typeof t[1] === 'string'
+    )
+  })
 }
 
 export function useTransit() {

--- a/frontend/src/types/transit.ts
+++ b/frontend/src/types/transit.ts
@@ -39,7 +39,7 @@ export function parseSummary(summary: string): {
   duration: string
   transfers: string
 } {
-  const timeMatch = summary.match(/(\d{1,2}:\d{2})(?:発\s*→\s*|～)(\d{1,2}:\d{2})(?:着)?/)
+  const timeMatch = summary.match(/(\d{1,2}:\d{2})(?:発\s{0,10}→\s{0,10}|～)(\d{1,2}:\d{2})(?:着)?/)
   const durationMatch = summary.match(/\((\d+時間\d+分|\d+時間|\d+分)\)/)
   const transfersMatch = summary.match(/\((\d+回)\)/)
 

--- a/frontend/tests/transit.test.ts
+++ b/frontend/tests/transit.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { parseTransitResponse, parseSummary, parseRoute } from '../src/types/transit'
+import { isValidTransitResponse } from '../src/hooks/useTransit'
 
 describe('parseTransitResponse', () => {
   it('should parse multi-origin transit response correctly', () => {
@@ -180,5 +181,131 @@ describe('parseRoute', () => {
     expect(result[0].isTerminal).toBe(false)
     expect(result[1].station).toBe('駅B')
     expect(result[1].isTerminal).toBe(false)
+  })
+})
+
+describe('isValidTransitResponse', () => {
+  it('rejects null', () => {
+    expect(isValidTransitResponse(null)).toBe(false)
+  })
+
+  it('rejects undefined', () => {
+    expect(isValidTransitResponse(undefined)).toBe(false)
+  })
+
+  it('rejects empty object', () => {
+    expect(isValidTransitResponse({})).toBe(false)
+  })
+
+  it('rejects routes that are not an array', () => {
+    expect(isValidTransitResponse({ routes: 'not array' })).toBe(false)
+  })
+
+  it('accepts empty routes array', () => {
+    expect(isValidTransitResponse({ routes: [] })).toBe(true)
+  })
+
+  it('accepts a route with empty transfers', () => {
+    expect(
+      isValidTransitResponse({ routes: [{ origin: 'A', destination: 'B', transfers: [] }] })
+    ).toBe(true)
+  })
+
+  it('accepts a route with valid string-tuple transfers', () => {
+    expect(
+      isValidTransitResponse({
+        routes: [{ origin: 'A', destination: 'B', transfers: [['s', 'r']] }],
+      })
+    ).toBe(true)
+  })
+
+  it('accepts the real Jorudan-shaped fixture', () => {
+    expect(
+      isValidTransitResponse({
+        routes: [
+          {
+            origin: '六本木一丁目',
+            destination: 'つつじヶ丘（東京）',
+            transfers: [
+              ['18:49発 → 19:38着(49分)(1回)', '■六本木一丁目\n｜東京メトロ南北線'],
+              ['18:55発 → 19:45着(50分)(2回)', '■六本木一丁目\n｜東京メトロ丸ノ内線'],
+            ],
+          },
+        ],
+      })
+    ).toBe(true)
+  })
+
+  it('rejects a route missing origin', () => {
+    expect(
+      isValidTransitResponse({ routes: [{ destination: 'B', transfers: [] }] })
+    ).toBe(false)
+  })
+
+  it('rejects a route missing destination', () => {
+    expect(
+      isValidTransitResponse({ routes: [{ origin: 'A', transfers: [] }] })
+    ).toBe(false)
+  })
+
+  it('rejects a route missing transfers', () => {
+    expect(
+      isValidTransitResponse({ routes: [{ origin: 'A', destination: 'B' }] })
+    ).toBe(false)
+  })
+
+  it('rejects non-string origin', () => {
+    expect(
+      isValidTransitResponse({ routes: [{ origin: 42, destination: 'B', transfers: [] }] })
+    ).toBe(false)
+  })
+
+  it('rejects non-array transfers', () => {
+    expect(
+      isValidTransitResponse({
+        routes: [{ origin: 'A', destination: 'B', transfers: 'not-array' }],
+      })
+    ).toBe(false)
+  })
+
+  it('rejects malformed nested: transfers contains a number', () => {
+    expect(
+      isValidTransitResponse({
+        routes: [{ origin: 'A', destination: 'B', transfers: [123] }],
+      })
+    ).toBe(false)
+  })
+
+  it('rejects malformed nested: transfers contains an object', () => {
+    expect(
+      isValidTransitResponse({
+        routes: [{ origin: 'A', destination: 'B', transfers: [{}] }],
+      })
+    ).toBe(false)
+  })
+
+  it('rejects malformed nested: transfers tuple has only one element', () => {
+    expect(
+      isValidTransitResponse({
+        routes: [{ origin: 'A', destination: 'B', transfers: [['only-one-string']] }],
+      })
+    ).toBe(false)
+  })
+
+  it('rejects malformed nested: transfers tuple second element is not a string', () => {
+    expect(
+      isValidTransitResponse({
+        routes: [{ origin: 'A', destination: 'B', transfers: [['s', 42]] }],
+      })
+    ).toBe(false)
+  })
+})
+
+describe('parseSummary ReDoS regression', () => {
+  it('completes quickly on a long whitespace-padded input', () => {
+    const start = performance.now()
+    parseSummary(' '.repeat(100000) + 'foo')
+    const elapsed = performance.now() - start
+    expect(elapsed).toBeLessThan(50)
   })
 })

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -231,6 +231,7 @@ async function fetchTransitPage(url) {
 
 const JSON_HEADERS = {
   'Content-Type': 'application/json',
+  'X-Content-Type-Options': 'nosniff',
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'Content-Type',
   'Access-Control-Allow-Methods': 'GET,OPTIONS',

--- a/tests/handler.test.mjs
+++ b/tests/handler.test.mjs
@@ -433,4 +433,9 @@ describe('CORS headers', () => {
     const result = await handler({ path: '/status' }, {});
     assert.strictEqual(result.headers['Access-Control-Allow-Methods'], 'GET,OPTIONS');
   });
+
+  it('should set X-Content-Type-Options to nosniff', async () => {
+    const result = await handler({ path: '/status' }, {});
+    assert.strictEqual(result.headers['X-Content-Type-Options'], 'nosniff');
+  });
 });


### PR DESCRIPTION
## Summary

Closes #32 — pentest findings **B1**, **B2**, **C3** in `.plans/crimson-weaving-falcon.md`.

### B1 — `isValidTransitResponse` strengthened

The previous guard only checked `routes` was an array. The downstream `parseTransitResponse()` (frontend/src/types/transit.ts:28-34) destructures each transfer as `[summary, route]`, so a malformed payload like `transfers: [123]` or `[{}]` would pass the old guard and crash at destructuring.

New guard validates:
- `origin` and `destination` are strings on every route
- `transfers` is an array on every route
- each transfer is a `[string, string]` tuple (length 2, both strings)

Function is also exported so vitest can call it directly.

### B2 — ReDoS bounded

`parseSummary` regex `(?:発\s*→\s*|～)` had unbounded `\s*` quantifiers in alternation. Replaced both with `\s{0,10}`. Verified equivalent matching on real Jorudan summaries (`'18:49発 → 19:38着(49分)(1回)'`, `'06:30～08:45'`, etc.) — all six existing `parseSummary` tests still pass.

### C3 — nosniff at Lambda layer

Added `'X-Content-Type-Options': 'nosniff'` to `JSON_HEADERS`. The CloudFront managed `SecurityHeadersPolicy` (added in #29) already injects the same value, so this is a redundant-but-harmless defense at the origin layer for cases where the API is hit directly (e.g., bypassing CloudFront).

## Test plan

- [x] `npm test` (root) — **50 pass / 0 fail** (was 49; +1 nosniff header assertion)
- [x] `npm test` (frontend) — **32 pass / 0 fail** (was 15; +16 type-guard cases + 1 ReDoS-regression timing test)
- [x] `npm run lint` (root) — clean
- [x] `cd frontend && npm run lint` — clean
- [x] `npm audit --audit-level=high` (root) — `found 0 vulnerabilities`
- [x] `cd frontend && npm audit --audit-level=high` — exit 0 (1 moderate postcss only, below high gate)
- [x] **Browser verification via Playwright MCP:** docker-compose up api-dev frontend-dev → navigate to http://localhost:3000/ → fetch `/api/status` from page context → response now carries `X-Content-Type-Options: nosniff`. UI rendered with the strengthened type guard accepting the real Jorudan response — **0 console errors / 0 warnings**.

## Type-guard test matrix

| Input | Expected | Why |
|-------|----------|-----|
| `null`, `undefined`, `{}`, `{routes: 'not array'}` | false | basic shape rejection |
| `{routes: []}` | true | empty list is valid |
| `{routes: [{origin, destination, transfers: []}]}` | true | empty transfers is valid |
| Real Jorudan fixture (`[['18:49発 → 19:38着…', '■…']]`) | true | positive case for production shape |
| missing `origin` / `destination` / `transfers` | false | required fields |
| non-string `origin` (number) | false | type strictness |
| non-array `transfers` | false | type strictness |
| **`transfers: [123]`** | false | malformed nested (Codex critical-finding gate) |
| **`transfers: [{}]`** | false | malformed nested |
| **`transfers: [['only-one-string']]`** | false | tuple length |
| **`transfers: [['s', 42]]`** | false | tuple element type |

## Files

- `frontend/src/hooks/useTransit.ts` — `isValidTransitResponse` strengthened + exported
- `frontend/src/types/transit.ts` — `parseSummary` regex bounded
- `src/index.mjs` — `JSON_HEADERS` gains `X-Content-Type-Options: 'nosniff'`
- `frontend/tests/transit.test.ts` — 16 type-guard cases + 1 ReDoS-regression timing test
- `tests/handler.test.mjs` — 1 nosniff header assertion

## Conflict notes

This is the last PR in the Issue #28 series. Rebased cleanly on top of #31's `JSON_HEADERS` change (the nosniff insertion is one line above #31's `Access-Control-Allow-Headers` edit; no conflict).

After merge: I will open a follow-up issue for **C17** (Content-Security-Policy on the CloudFront default behavior — split off from #29 because the AWS managed `SecurityHeadersPolicy` does not include CSP), and confirm Issue #28 closes.