### PR TITLE
fix(infra): preserve CloudFront WebACL attachment in SAM template

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -76,9 +76,61 @@ jobs:
       - name: SAM Build
         run: sam build
 
+      - name: SAM Deploy (dry-run plan)
+        if: ${{ github.event.inputs.dry-run == 'true' }}
+        run: |
+          if [ -z "${{ secrets.WEB_ACL_ARN_PROD }}" ]; then
+            echo "::error::WEB_ACL_ARN_PROD secret is not set on the production environment."
+            exit 1
+          fi
+          set -o pipefail
+          sam deploy \
+            --no-execute-changeset \
+            --no-fail-on-empty-changeset \
+            --resolve-s3 \
+            --parameter-overrides "WebACLArn=${{ secrets.WEB_ACL_ARN_PROD }}" \
+            2>&1 | tee /tmp/sam-deploy-output.log
+
+      - name: Describe pending changeset
+        if: ${{ github.event.inputs.dry-run == 'true' }}
+        run: |
+          # Extract the changeset ARN that sam deploy --no-execute-changeset just printed.
+          CHANGESET_ARN=$(grep -oE 'arn:aws:cloudformation:[^[:space:]]+:changeSet/[^[:space:]]+' /tmp/sam-deploy-output.log | tail -1)
+          if [ -z "$CHANGESET_ARN" ]; then
+            echo "::error::Could not extract changeset ARN from sam deploy output. Either no changeset was created (template == live state, in which case this PR is a no-op and unsafe to land) or sam output format changed."
+            exit 1
+          fi
+          echo "Changeset ARN: $CHANGESET_ARN"
+          aws cloudformation describe-change-set \
+            --change-set-name "$CHANGESET_ARN" \
+            --query 'Changes[].{Action:ResourceChange.Action,Type:ResourceChange.ResourceType,Logical:ResourceChange.LogicalResourceId,Replacement:ResourceChange.Replacement}' \
+            --output table
+
+          # Hard gate: WebACLId change must be present on CloudFrontDistribution
+          WEBACL_DIFF=$(aws cloudformation describe-change-set \
+            --change-set-name "$CHANGESET_ARN" \
+            --query 'Changes[?ResourceChange.LogicalResourceId==`CloudFrontDistribution`].ResourceChange.Details[?Target.Name==`WebACLId`]' \
+            --output json)
+          if [ "$(echo "$WEBACL_DIFF" | jq 'flatten | length')" -eq 0 ]; then
+            echo "::error::Dry-run changeset does NOT include a WebACLId change on CloudFrontDistribution. Either the secret is wrong, the live state already matches the template (so this PR adds no value), or the template-side WebACLId line is missing/inert."
+            echo "$WEBACL_DIFF"
+            exit 1
+          fi
+          echo "WebACLId change verified:"
+          echo "$WEBACL_DIFF" | jq .
+
       - name: SAM Deploy
         if: ${{ github.event.inputs.dry-run != 'true' }}
-        run: sam deploy --no-confirm-changeset --no-fail-on-empty-changeset --resolve-s3
+        run: |
+          if [ -z "${{ secrets.WEB_ACL_ARN_PROD }}" ]; then
+            echo "::error::WEB_ACL_ARN_PROD secret is not set on the production environment."
+            exit 1
+          fi
+          sam deploy \
+            --no-confirm-changeset \
+            --no-fail-on-empty-changeset \
+            --resolve-s3 \
+            --parameter-overrides "WebACLArn=${{ secrets.WEB_ACL_ARN_PROD }}"
 
       - name: Get Stack Outputs
         if: ${{ github.event.inputs.dry-run != 'true' }}
@@ -121,3 +173,12 @@ jobs:
           sleep 30  # Wait for CloudFront invalidation
           curl -f "${{ steps.stack-outputs.outputs.frontend_url }}" || exit 1
           curl -f "${{ steps.stack-outputs.outputs.frontend_url }}/api/status" || exit 1
+          # Verify CloudFront SecurityHeadersPolicy applied to /api/* (PR #35)
+          headers=$(curl -sI "${{ steps.stack-outputs.outputs.frontend_url }}/api/status")
+          for h in 'strict-transport-security' 'x-content-type-options' 'x-frame-options'; do
+            if ! echo "$headers" | grep -qi "^$h:"; then
+              echo "::error::Security header $h missing from /api/status response"
+              echo "$headers"
+              exit 1
+            fi
+          done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,13 +52,27 @@ npm run lint               # Backend lint
 cd frontend && npm run lint # Frontend lint
 
 # SAM deployment (includes CloudFront + S3)
-sam build && sam deploy
+sam build && sam deploy   # NON-PROD STACKS ONLY — see Production deploys below
 
 # Frontend deployment (after SAM deploy)
 cd frontend && npm run build
 aws s3 sync dist/ s3://<bucket-name>/
 aws cloudfront create-invalidation --distribution-id <id> --paths "/*"
 ```
+
+### Production deploys
+
+> **Production deploys MUST go through the `Deploy to Production` GitHub Actions workflow** (`workflow_dispatch`). The CloudFront distribution is protected by a Web ACL that AWS's CloudFront pricing-plan subscription requires to remain attached. The Web ACL ARN is held in the `WEB_ACL_ARN_PROD` secret on the `production` GitHub environment, and the workflow injects it via `--parameter-overrides`. Running plain `sam deploy` locally against the production stack would re-render the distribution without `WebACLId` — CloudFront then refuses with "You can't remove or replace the web ACL for your distribution. Distributions with a pricing plan subscription must have a web ACL resource." and rolls back.
+
+For emergency local deploys (only when GitHub Actions is unavailable):
+
+```bash
+WEB_ACL_ARN_PROD="arn:aws:wafv2:us-east-1:<ACCT>:global/webacl/<NAME>/<UUID>"  # retrieve from a secure store
+sam build
+sam deploy --parameter-overrides "WebACLArn=$WEB_ACL_ARN_PROD"
+```
+
+The Web ACL itself is **not** managed by this stack (it was created by the CloudFront pricing-plan opt-in). Do not edit the Web ACL attachment in the AWS console — the next CFN deploy will reconcile to whatever ARN is in the secret. If the Web ACL is ever recreated and the ARN changes, update the secret first.
 
 ## Key Implementation Notes
 

--- a/template.yml
+++ b/template.yml
@@ -3,6 +3,20 @@ AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: Transit app with Lambda API and CloudFront + S3 frontend
 
+Parameters:
+  WebACLArn:
+    Type: String
+    Default: ''
+    Description: |
+      ARN of the WAFv2 Web ACL (Scope: CLOUDFRONT, region us-east-1) attached to the
+      CloudFront distribution. Required in production where a CloudFront pricing-plan
+      subscription mandates a Web ACL. Leave empty in non-prod stacks.
+    AllowedPattern: '^$|^arn:aws:wafv2:us-east-1:\d{12}:global/webacl/[^/]+/[a-f0-9-]+$'
+    ConstraintDescription: Must be empty or a WAFv2 CLOUDFRONT-scope Web ACL ARN in us-east-1.
+
+Conditions:
+  HasWebACL: !Not [!Equals [!Ref WebACLArn, '']]
+
 Globals:
   Api:
     Cors:
@@ -115,6 +129,7 @@ Resources:
         HttpVersion: http2
         PriceClass: PriceClass_200
         Comment: !Sub '${AWS::StackName} Frontend Distribution'
+        WebACLId: !If [HasWebACL, !Ref WebACLArn, !Ref AWS::NoValue]
 
         Origins:
           # S3 Origin for static files


### PR DESCRIPTION
## Summary

Closes the production deploy failure from [run 25554289022](https://github.com/mikanmarusan/lambda-function-transit/actions/runs/25554289022/job/75009459796) — `AWS::CloudFront::Distribution` UPDATE_FAILED with:

> "Invalid request provided: You can't remove or replace the web ACL for your distribution. Distributions with a pricing plan subscription must have a web ACL resource."

### Root cause

PR #35 (Issue #29) was the only PR in the recent batch that modified `template.yml`'s CloudFront resource (added `ResponseHeadersPolicyId` to `/api/*`). The live production distribution has a Web ACL attached out-of-band (auto-created by the AWS Console when the CloudFront pricing-plan subscription was opted into — the ACL name `CreatedByCloudFront-26c0b6f0` confirms this), and the pricing plan **mandates** that the Web ACL stay attached. CFN serialized the distribution without `WebACLId` (because `template.yml` didn't declare one) and CloudFront refused.

### Forward-fix (per user direction)

Keep PR #35's headers; declare the live Web ACL in `template.yml` so future CloudFront updates preserve the attachment.

## Changes

### `template.yml`
- New `Parameters.WebACLArn` block with `AllowedPattern` pinning to WAFv2 CLOUDFRONT-scope ARNs in `us-east-1`.
- New `Conditions.HasWebACL`.
- One-line `WebACLId: !If [HasWebACL, !Ref WebACLArn, !Ref AWS::NoValue]` on `DistributionConfig`. The `AWS::NoValue` fallback lets non-prod stacks still deploy without an ARN.

### `.github/workflows/deploy-production.yml`
- `SAM Deploy` step now requires the `WEB_ACL_ARN_PROD` secret on the `production` environment and passes it via `--parameter-overrides`. Both real and dry-run paths.
- **Dry-run upgraded** from `sam build`-only to `sam deploy --no-execute-changeset` (so the next class of CFN-vs-live drift is actually caught).
- New `Describe pending changeset` step (dry-run only) parses the changeset ARN from `sam deploy` stdout and hard-fails if the WebACLId diff is missing on `CloudFrontDistribution`.
- `Health Check - Frontend` now also asserts the three security headers promised by PR #35 (HSTS, X-Content-Type-Options, X-Frame-Options).

### `CLAUDE.md`
- New `Production deploys` subsection forbidding uncontrolled local `sam deploy` against production and documenting the emergency procedure with `--parameter-overrides "WebACLArn=$WEB_ACL_ARN_PROD"`.

## Where the ARN lives

**Not in the repo.** Stored as `WEB_ACL_ARN_PROD` on the `production` GitHub Actions environment. This avoids leaking the AWS account ID and the WAF rule-set name (the repo is public; account ID currently never appears in source — only `!Sub ${AWS::AccountId}`).

## Test plan

- [x] **`sam validate --lint`** (via `public.ecr.aws/sam/build-nodejs22.x:latest` Docker image) — `template.yml is a valid SAM Template`
- [x] **`sam build --parameter-overrides "WebACLArn=arn:aws:wafv2:us-east-1:..."`** — Build Succeeded; `.aws-sam/build/template.yaml` contains `WebACLId: { Fn::If: [HasWebACL, Ref: WebACLArn, Ref: AWS::NoValue] }`
- [x] **`sam build` (empty default)** — Build Succeeded; same conditional structure; CFN evaluates to `AWS::NoValue` so the property is omitted entirely on stacks without an ARN
- [x] `WEB_ACL_ARN_PROD` secret set on `production` environment (verified via `gh secret list --env production`)
- [ ] **After merge, run workflow with `dry-run=true`** — `Describe pending changeset` must show `Modify CloudFrontDistribution` with the WebACLId diff, and the hard-gate jq assertion must pass
- [ ] **Then run with `dry-run=false`** — stack must reach `UPDATE_COMPLETE`; the new health-check assertions must pass for the three security headers

## Out of scope (follow-ups)

- `chore(ci): add sam validate --lint to ci.yml` — catch template typos at PR time
- `chore(infra): scheduled CFN drift detection` — alert on console-side ACL changes
- `chore(infra): migrate AWS auth to OIDC, add CODEOWNERS, SHA-pin actions` — broader CI/security hardening

I'll open these as separate issues after this PR merges.