### PR TITLE
fix(infra): conditional PriceClass to satisfy CloudFront flat-rate plan

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -127,7 +127,12 @@ Resources:
         Enabled: true
         DefaultRootObject: index.html
         HttpVersion: http2
-        PriceClass: PriceClass_200
+        # PriceClass is locked by the CloudFront flat-rate pricing plan that mandates the
+        # Web ACL (see WebACLId below). When the plan is active, any explicit PriceClass
+        # override is rejected with "Distributions with the Free pricing plan can't have
+        # the following features: Price class". We therefore omit PriceClass on stacks
+        # that have the WebACL (= flat-rate plan), and keep PriceClass_200 elsewhere.
+        PriceClass: !If [HasWebACL, !Ref AWS::NoValue, PriceClass_200]
         Comment: !Sub '${AWS::StackName} Frontend Distribution'
         WebACLId: !If [HasWebACL, !Ref WebACLArn, !Ref AWS::NoValue]
 


### PR DESCRIPTION
## Summary

The first real deploy after #39/#43 reached CloudFront update and failed with:

> "Invalid request provided: Distributions with the Free pricing plan can't have the following features: Price class"

The production distribution is on the CloudFront **Free** flat-rate plan (same plan that mandates the WebACL preserved in #39). The plan locks \`PriceClass\` to AWS's default and rejects any explicit override. Pre-Issue-#28 deploys never modified the CloudFront resource, so this latent template-vs-live incompatibility never surfaced — it only showed up once we started actually pushing CloudFront updates.

## Fix

Make \`PriceClass\` conditional on \`HasWebACL\`:

\`\`\`yaml
PriceClass: !If [HasWebACL, !Ref AWS::NoValue, PriceClass_200]
\`\`\`

- **Production** (HasWebACL=true → flat-rate plan active): \`PriceClass\` omitted, CFN doesn't try to override, CloudFront accepts.
- **Non-prod** (no WebACL): keeps the \`PriceClass_200\` cost optimization.

\`HasWebACL\` doubles as a "flat-rate plan active" signal because the plan attaches a Web ACL by definition. A dedicated \`FlatRatePlanActive\` Parameter would be cleaner but is over-engineered for a one-prod-stack personal app. The new comment in \`template.yml\` documents the assumption.

## Test plan

- [x] \`sam validate --lint\` (Docker) → \`template.yml is a valid SAM Template\`
- [x] \`sam build --parameter-overrides "WebACLArn=arn:aws:wafv2:..."\` → built template renders:
  \`\`\`yaml
  PriceClass:
    Fn::If:
    - HasWebACL
    - Ref: AWS::NoValue
    - PriceClass_200
  \`\`\`
- [ ] After merge: \`Deploy to Production\` workflow with \`dry-run=true\` should pass
- [ ] Then \`dry-run=false\` should reach \`UPDATE_COMPLETE\` (the previous failure was at the CloudFront update step; this fix removes the only remaining override-vs-Free-plan conflict I'm aware of)

## Related

- Same root cause family as #39 (WebACL) and #43 (gate fix-up) — out-of-band drift between the IaC template and the CloudFront flat-rate plan's restrictions. The flat-rate plan was opted-into via the AWS Console at some point and silently changed several distribution settings; we're reconciling them one by one as deploys surface them.