### PR TITLE
chore(infra): migrate AWS auth from access keys to GitHub OIDC

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -55,6 +55,9 @@ jobs:
     needs: build-frontend
     runs-on: ubuntu-latest
     environment: production
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -63,8 +66,7 @@ jobs:
       - uses: aws-actions/setup-sam@v2
       - uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_PROD }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_PROD }}
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN_PROD }}
           aws-region: ap-northeast-1
 
       - name: Download frontend artifacts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,8 @@ aws cloudfront create-invalidation --distribution-id <id> --paths "/*"
 
 > **Production deploys MUST go through the `Deploy to Production` GitHub Actions workflow** (`workflow_dispatch`). The CloudFront distribution is protected by a Web ACL that AWS's CloudFront pricing-plan subscription requires to remain attached. The Web ACL ARN is held in the `WEB_ACL_ARN_PROD` secret on the `production` GitHub environment, and the workflow injects it via `--parameter-overrides`. Running plain `sam deploy` locally against the production stack would re-render the distribution without `WebACLId` — CloudFront then refuses with "You can't remove or replace the web ACL for your distribution. Distributions with a pricing plan subscription must have a web ACL resource." and rolls back.
 
+The workflow authenticates to AWS via GitHub OIDC. The IAM Role ARN (`gh-actions-deploy-prod`) is held in the `AWS_DEPLOY_ROLE_ARN_PROD` secret on the `production` environment; its trust policy pins assumption to `repo:mikanmarusan/lambda-function-transit:environment:production`, so no other repo or environment can use it and no long-lived AK/SK exist for prod deploy.
+
 Emergency local deploys (only when GitHub Actions is unavailable):
 
 ```bash


### PR DESCRIPTION
## Summary

Closes Item 1 of #42 — replaces long-lived `AWS_ACCESS_KEY_ID_PROD` / `AWS_SECRET_ACCESS_KEY_PROD` on the `deploy-production.yml` job with GitHub OIDC role assumption. Items 2 (CODEOWNERS) and 3 (SHA-pin) of #42 are intentionally **not** addressed here per direction.

## Why now

- Long-lived AK/SK have an infinite leak window and full-account blast radius if exposed. OIDC issues ~1h STS tokens scoped to this repo + `production` environment via the IAM trust policy, so leak risk drops by orders of magnitude.
- Doing this before any future drift-detection work (#41) avoids minting another long-lived read-only credential pair.

## Changes

- `.github/workflows/deploy-production.yml`
  - Add job-level `permissions: { id-token: write, contents: read }` on `deploy`.
  - Replace `aws-access-key-id` / `aws-secret-access-key` inputs with `role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN_PROD }}`.
- `CLAUDE.md`
  - Document the OIDC role + secret in the "Production deploys" section.

## :warning: Do not merge until AWS-side prereqs are complete

The workflow will fail at `configure-aws-credentials` if these are not done first:

1. **OIDC identity provider** exists in the prod AWS account for `https://token.actions.githubusercontent.com` (audience `sts.amazonaws.com`).
2. **IAM Role `gh-actions-deploy-prod`** exists with the trust policy below.
3. The role has **the same permissions** the old `AWS_ACCESS_KEY_ID_PROD` IAM user had.
4. **`AWS_DEPLOY_ROLE_ARN_PROD`** secret is set on the `production` GitHub environment.

Trust policy (replace `<ACCT>`):

```json
{
  "Version": "2012-10-17",
  "Statement": [{
    "Effect": "Allow",
    "Principal": { "Federated": "arn:aws:iam::<ACCT>:oidc-provider/token.actions.githubusercontent.com" },
    "Action": "sts:AssumeRoleWithWebIdentity",
    "Condition": {
      "StringEquals": {
        "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
        "token.actions.githubusercontent.com:sub": "repo:mikanmarusan/lambda-function-transit:environment:production"
      }
    }
  }]
}
```

Full step-by-step copy-pasteable commands are in `.plans/oidc-aws-auth-42.md` (gitignored). They cover: OIDC provider check/create, role create, policy migration from the old user, secret registration, and post-cutover cleanup of the old AK/SK + IAM user.

## Cutover

1. Complete the four AWS-side prereqs above.
2. Merge this PR.
3. Run `Deploy to Production` with `dry-run=true`. Expect: OIDC assume succeeds, `sam deploy --no-execute-changeset` succeeds, the WebACL secret-vs-live check passes.
4. If green, run `dry-run=false`.
5. After one successful real deploy, delete the old IAM user and the `AWS_ACCESS_KEY_ID_PROD` / `AWS_SECRET_ACCESS_KEY_PROD` secrets.

The old secrets are intentionally **kept in place** until step 5 so a revert of this PR fully restores the previous deploy path.

## Test plan

- [ ] AWS-side prereqs (Steps A–D in the plan file) completed.
- [ ] `Deploy to Production` with `dry-run=true` succeeds end-to-end under OIDC.
- [ ] `Deploy to Production` with `dry-run=false` succeeds; health checks pass.
- [ ] Old IAM user + AK/SK deleted; corresponding GitHub secrets removed.