### PR TITLE
chore(ci): add sam validate --lint to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,3 +72,12 @@ jobs:
         run: |
           npm ci
           npm audit --audit-level=high
+
+  validate-template:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
+      - run: sam validate --lint


### PR DESCRIPTION
## Summary

Adds a `validate-template` job to `ci.yml` that runs `sam validate --lint` against `template.yml` on every push/PR. The lint runs offline against the local file — no AWS auth, no parameter overrides (the `WebACLArn` parameter defaults to `""` and lint mode evaluates schema + cfn-lint rules, not intrinsics).

This catches SAM/CFN template regressions at PR time rather than at production deploy time.

## Implementation

- New `validate-template` job parallel to existing jobs (`test-backend`, `test-frontend`, `docker-build`, `security`); no `needs:` chain.
- Reuses `aws-actions/setup-sam@v2` (already used in `deploy-production.yml`).
- Uses `use-installer: true` to avoid intermittent pip-install flakiness of `setup-sam@v2`.

## Test plan

- [x] Pre-PR verification: ran `sam validate --lint` against `main`'s `template.yml` via `public.ecr.aws/sam/build-nodejs22.x` Docker image — result: `template.yml is a valid SAM Template`.
- [ ] This PR's own CI run reports green on the new `validate-template` job.

Closes #40.