### PR TITLE
chore(infra): add in-deploy CloudFormation drift detection

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -59,6 +59,11 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - name: Mask WEB_ACL_ARN_PROD across job logs
+        env:
+          WEB_ACL_ARN_PROD: ${{ secrets.WEB_ACL_ARN_PROD }}
+        run: echo "::add-mask::$WEB_ACL_ARN_PROD"
+
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
@@ -77,6 +82,52 @@ jobs:
 
       - name: SAM Build
         run: sam build
+
+      - name: Detect CloudFormation drift
+        run: |
+          set -o pipefail
+          STACK=transitmikanmarusan
+          DETECTION_ID=$(aws cloudformation detect-stack-drift \
+            --stack-name "$STACK" \
+            --query 'StackDriftDetectionId' --output text)
+          echo "DriftDetectionId: $DETECTION_ID"
+
+          SLEEP=5
+          STATUS_JSON=""
+          DETECTION_STATUS=""
+          for i in $(seq 1 20); do
+            STATUS_JSON=$(aws cloudformation describe-stack-drift-detection-status \
+              --stack-drift-detection-id "$DETECTION_ID" --output json)
+            DETECTION_STATUS=$(echo "$STATUS_JSON" | jq -r '.DetectionStatus')
+            echo "Attempt $i: DetectionStatus=$DETECTION_STATUS"
+            if [ "$DETECTION_STATUS" != "DETECTION_IN_PROGRESS" ]; then
+              break
+            fi
+            sleep "$SLEEP"
+            if [ "$SLEEP" -lt 30 ]; then SLEEP=$((SLEEP + 5)); fi
+          done
+
+          if [ "$DETECTION_STATUS" = "DETECTION_FAILED" ]; then
+            echo "::error::Drift detection failed: $(echo "$STATUS_JSON" | jq -r '.DetectionStatusReason')"
+            exit 1
+          fi
+          if [ "$DETECTION_STATUS" != "DETECTION_COMPLETE" ]; then
+            echo "::error::Drift detection did not complete in time (last status=$DETECTION_STATUS). Re-run the workflow."
+            exit 1
+          fi
+
+          DRIFT_STATUS=$(echo "$STATUS_JSON" | jq -r '.StackDriftStatus')
+          if [ "$DRIFT_STATUS" != "IN_SYNC" ]; then
+            echo "::error::Stack $STACK is $DRIFT_STATUS. Drifted resources:"
+            aws cloudformation describe-stack-resource-drifts \
+              --stack-name "$STACK" \
+              --stack-resource-drift-status-filters MODIFIED DELETED \
+              --query 'StackResourceDrifts[].{Logical:LogicalResourceId,Type:ResourceType,Status:StackResourceDriftStatus}' \
+              --output table
+            echo "Remediate by either (a) updating template.yml to absorb the change, or (b) reverting the console change, then re-run this workflow."
+            exit 1
+          fi
+          echo "Stack is IN_SYNC."
 
       - name: Verify WEB_ACL_ARN_PROD secret matches live distribution
         run: |


### PR DESCRIPTION
## Summary

Implements the lighter design for Issue #41 (in-deploy drift gate, no cron, no auto-Issue, no exception list) as agreed in the Issue comment thread.

- New `Detect CloudFormation drift` step inserted between `SAM Build` and `Verify WEB_ACL_ARN_PROD secret matches live distribution`. Polls `describe-stack-drift-detection-status` with bounded backoff (~5 min cap). On `DETECTION_FAILED` or `StackDriftStatus != IN_SYNC`, prints actionable `::error::` output and `exit 1`.
- New `Mask WEB_ACL_ARN_PROD across job logs` step as the very first step of the `deploy` job. Emits `::add-mask::$WEB_ACL_ARN_PROD` so any subsequent log line (notably the new `describe-stack-resource-drifts` output) cannot leak the WebACL ARN through public workflow logs.
- Both edits apply to `dry-run=true` and `dry-run=false` paths — dry-run is intentionally a real pre-flight.
- No IAM change required. The OIDC role `gh-actions-deploy-prod` already has `AWSCloudFormationFullAccess`, which covers all three drift API actions.

## Pre-merge verification

- [x] Phase 0 drift probe via local AWS CLI: `aws cloudformation detect-stack-drift --stack-name transitmikanmarusan` → `DetectionStatus=DETECTION_COMPLETE`, `StackDriftStatus=IN_SYNC`, `DriftedStackResourceCount=0`. The new step will pass on its first real run.
- [x] OIDC role `gh-actions-deploy-prod` policy attachment confirmed: `AWSCloudFormationFullAccess` present (unchanged since #51).
- [x] **Pre-push workflow lint**: ran `rhysd/actionlint:1.7.1` against the modified file. The 6 findings emitted by actionlint are all in **pre-existing untouched steps** (`Describe pending changeset` L173, `Get Stack Outputs` L213); the new code (Mask step + Detect CloudFormation drift step) is clean. A follow-up Issue to add `actionlint` to `ci.yml` as a durable CI-side gate (and to clean up the pre-existing shellcheck warnings) will be opened post-merge.

## Test plan

- [ ] PR CI green (existing 5 jobs unchanged by this PR).
- [ ] After merge: trigger `Deploy to Production` with `dry-run=true`. Expect: new `Mask WEB_ACL_ARN_PROD across job logs` step runs first, `Detect CloudFormation drift` step polls and prints `Stack is IN_SYNC.`, then `Verify WEB_ACL_ARN_PROD secret matches live distribution`, `SAM Deploy (dry-run plan)`, and `Describe pending changeset` proceed.
- [ ] Then trigger with `dry-run=false`. Expect: drift step green, `SAM Deploy` likely `No changes to deploy.` (template unchanged), S3 sync, CloudFront invalidation, both health checks green incl. the three security headers.

Closes #41.