### PR TITLE
refactor(skills): rename skills to x-<verb>ing-<domain> gerund pattern

### DIFF
--- a/.claude/skills/x-fixing-vulnerabilities/SKILL.md
+++ b/.claude/skills/x-fixing-vulnerabilities/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: x-fix-vulnerability
+name: x-fixing-vulnerabilities
 description: Detect and fix npm audit vulnerabilities in root and frontend directories, matching CI audit level (--audit-level=high).
 ---
 

--- a/.claude/skills/x-pentesting/SKILL.md
+++ b/.claude/skills/x-pentesting/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: x-pentest
+name: x-pentesting
 description: End-to-end penetration test for the transit Lambda backend and React frontend — static analysis, live pentest against dev-server.mjs, plan file generation, and optional GitHub issue creation with native sub-issues. Use when running a comprehensive pentest or after major backend/frontend changes.
 ---
 
@@ -25,7 +25,7 @@ This skill produces the following artifacts on every run:
 
 ### What this skill does NOT do
 
-- Does not apply any fixes automatically (use `/x-fix-vulnerability` for npm audit fixes or `/x-fix-issue` for specific issue resolution)
+- Does not apply any fixes automatically (use `/x-fixing-vulnerabilities` for npm audit fixes or `/x-fix-issue` for specific issue resolution)
 - Does not test AWS infrastructure in production (IAM deep audit, S3 bucket policies, CloudFront live headers)
 - Does not test the Vite frontend dev server (only tests the backend dev server at port 8000)
 - Does not produce compliance mapping (SOC2, PCI-DSS)
@@ -266,7 +266,7 @@ Required sections (in order):
 
 This phase runs only if the user chose "Create GitHub Issues" in Phase 5.
 
-1. Check `gh auth status`. If not authenticated, stop and report: "Run `gh auth login` to authenticate, then re-run `/x-pentest <slug>`."
+1. Check `gh auth status`. If not authenticated, stop and report: "Run `gh auth login` to authenticate, then re-run `/x-pentesting <slug>`."
 2. Propose an issue grouping strategy based on the findings. Default proposal: **parent Epic plus sub-issues grouped by PR boundary** (group findings that touch the same file or subsystem).
 3. **User interaction gate #3**: present via `AskUserQuestion` with these choices:
    - Accept the default grouping
@@ -295,9 +295,9 @@ Output a Markdown summary to the user containing:
 - If Phase 6 was executed: parent Epic URL and child issue URLs
 - If Phase 6 was skipped: note that issues were not created, suggest manual creation
 - Suggested next actions:
-  - `/x-fix-vulnerability` if any npm audit findings were flagged
+  - `/x-fixing-vulnerabilities` if any npm audit findings were flagged
   - `/x-fix-issue <child number>` if issues were created
-  - Re-run `/x-pentest` after fixes merge
+  - Re-run `/x-pentesting` after fixes merge
 
 Clean up: optionally remove `/tmp/pentest-${SLUG}.js`, `/tmp/pentest-results-${SLUG}.txt`, and `/tmp/probe-${SLUG}.js` (but keep them if the user wants to re-run tests manually).
 
@@ -639,7 +639,7 @@ Note: npm audit (test 6) is run separately via Bash during Phase 3, not inside t
 
 ## Verification Procedure
 
-After fixes are applied, re-run `/x-pentest` and confirm the previously-confirmed vulnerabilities no longer appear in Phase 3 test results.
+After fixes are applied, re-run `/x-pentesting` and confirm the previously-confirmed vulnerabilities no longer appear in Phase 3 test results.
 
 ## Raw Execution Results
 


### PR DESCRIPTION
## Summary

Align the two repo-local Claude Code skills with Anthropic's gerund naming recommendation and the `mikanmarusan-settings` `x-...` convention. Surface here is just two `SKILL.md` files plus two `git mv` operations; no agents, workflows, or docs reference these slash-commands.

## Breaking change

Any caller invoking these skills by old slash-command path will break. Only known consumer is the repository owner.

| Type  | Old                   | New                         |
| ----- | --------------------- | --------------------------- |
| Skill | `x-fix-vulnerability` | `x-fixing-vulnerabilities`  |
| Skill | `x-pentest`           | `x-pentesting`              |

## Changes

- `git mv .claude/skills/x-fix-vulnerability   .claude/skills/x-fixing-vulnerabilities` (history preserved, R98)
- `git mv .claude/skills/x-pentest             .claude/skills/x-pentesting` (history preserved, R98)
- `name:` frontmatter in each `SKILL.md` updated to match its new directory (lockstep invariant satisfied in the same commit)
- 5 in-repo prose references to `/x-fix-vulnerability` and `/x-pentest` updated in `x-pentesting/SKILL.md` (lines 28, 269, 298, 300, 642)

## Verification

- `git grep -nE "x-(fix-vulnerability|pentest)([^a-z]|$)" -- ':!.plans/'` returns zero matches
- Each `SKILL.md` frontmatter `name:` matches its parent directory name
- `git log --diff-filter=R --name-status` shows the two directory renames (rename, not delete + add)
- `npm run lint` passes
- Smoke check: skills list in a fresh session shows `x-fixing-vulnerabilities` and `x-pentesting`
- `x-code-reviewer` reports zero Critical, zero Warning

## Notes

- `.plans/` is intentionally excluded — historical artifact, not rewritten.
- `.claude/settings.local.json` is gitignored; the local allow-list will need to re-approve under the new skill names on first invocation post-merge.

Closes #50