### PR TITLE
chore(ci): bump GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
   test-backend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -25,8 +25,8 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -40,7 +40,7 @@ jobs:
   docker-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build development image
         run: docker build --target development -t transit-dev .
       - name: Build production image
@@ -61,8 +61,8 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
       - run: npm ci
@@ -76,8 +76,8 @@ jobs:
   validate-template:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: aws-actions/setup-sam@v2
+      - uses: actions/checkout@v6
+      - uses: aws-actions/setup-sam@v3
         with:
           use-installer: true
       - run: sam validate --lint

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event.inputs.confirmation == 'deploy'
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
       - run: npm ci
@@ -33,8 +33,8 @@ jobs:
     needs: validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -45,7 +45,7 @@ jobs:
           npm ci
           npm run build
       - name: Upload frontend artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: frontend-dist
           path: frontend/dist
@@ -64,18 +64,18 @@ jobs:
           WEB_ACL_ARN_PROD: ${{ secrets.WEB_ACL_ARN_PROD }}
         run: echo "::add-mask::$WEB_ACL_ARN_PROD"
 
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
-      - uses: aws-actions/setup-sam@v2
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/setup-sam@v3
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN_PROD }}
           aws-region: ap-northeast-1
 
       - name: Download frontend artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: frontend-dist
           path: frontend/dist


### PR DESCRIPTION
## Summary

Bumps every GitHub Action pin in both workflows off Node.js 20 to its latest Node.js 24 major, clearing the `Node.js 20 actions are deprecated` annotation ahead of the 2026-09-16 runner removal (and the 2026-06-02 forced-Node-24 default).

Upstream moved past the `v5` the Issue anticipated. Critically, `upload-artifact@v5` and `download-artifact@v5/v6` still **default to running on Node 20** internally (per their own v6/v7 release notes), so they would NOT clear the deprecation annotation. Each target major below was verified to expose `runs.using: node24` in its published `action.yml`, satisfying the Issue's "v5 or later" instruction while actually meeting the acceptance criteria.

## Changes

| Action | Before | After | Node 24 confirmed |
|---|---|---|---|
| `actions/checkout` | `@v4` | `@v6` | yes |
| `actions/setup-node` | `@v4` | `@v6` | yes |
| `actions/upload-artifact` | `@v4` | `@v7` | yes |
| `actions/download-artifact` | `@v4` | `@v8` | yes |
| `aws-actions/configure-aws-credentials` | `@v4` | `@v6` | yes |
| `aws-actions/setup-sam` | `@v2` | `@v3` | yes |

- `aws-actions/setup-sam` now has a Node 24 major (`v3`, tracks `v2`), so the Issue's "revisit if no major exists" note is resolved.
- `@v<major>` (non-SHA) pinning style kept intentionally, per the Issue's out-of-scope note.

## Breaking-change review (vs this repo's actual usage)

All clear — confirmed by reading each major's release notes and the x-code-reviewer agent:

- **checkout v6**: only caller-visible change is credential-file persistence; repo does bare checkouts.
- **setup-node v6**: auto package-manager-cache triggers only on a `packageManager` field (absent in both `package.json`); explicit `cache: 'npm'` steps unaffected.
- **upload-artifact v7**: ESM + optional `archive` param (defaults `true`); repo uses `name`/`path`/`retention-days`.
- **download-artifact v8**: v5 path breaking change affects download-by-ID only (repo downloads by `name`); new `digest-mismatch: error` default is a security improvement; zip round-trip with upload v7 is intact.
- **configure-aws-credentials v6**: v5 invalid-boolean cleanup doesn't apply (repo passes only `role-to-assume` + `aws-region`).
- **setup-sam v3**: node24 only, tracks v2.

All targets require Actions Runner >= v2.327.1, which GitHub-hosted `ubuntu-latest` already exceeds.

## Verification

- Both workflow files parse as valid YAML.
- No `lint`/`typecheck` script applies — the change touches only workflow YAML, not backend JS or frontend TS.
- x-code-reviewer: Approve, zero Critical / zero Warning.
- Acceptance criteria (no Node 20 annotation on fresh `ci.yml` + `Deploy to Production` dry-run runs; all jobs green) to be confirmed by the CI run on this PR and a `dry-run=true` `Deploy to Production` from this branch.

Closes #53