### PR TITLE
docs(adr): scaffold docs/adr with template, seed ADR, and INDEX

### DIFF
--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,20 @@
+---
+status: Proposed
+# applyTo is a local extension to MADR-Minimal (not a standard MADR field):
+# a repo-relative glob naming the blast radius the decision governs.
+applyTo: <repo-relative glob>
+---
+
+# NNNN. <Title>
+
+## Status
+Proposed
+
+## Context
+<the forces and the problem to solve>
+
+## Decision
+<the chosen option and why>
+
+## Consequences
+<positive and negative results; name at least one negative>

--- a/docs/adr/0001-jorudan-cookie-flow-scraper.md
+++ b/docs/adr/0001-jorudan-cookie-flow-scraper.md
@@ -1,0 +1,54 @@
+---
+status: Accepted
+applyTo: src/index.mjs
+---
+
+# 0001. Jorudan 3-step cookie-flow scraper on AWS Lambda
+
+## Status
+Accepted
+
+<!--
+Note: `status: Accepted` here is a deliberate hand-seed of an already-live
+decision. It deviates from the x-recording-adr skill's Proposed-only
+automated-write rule because this ADR documents a foundational choice that
+shipped long before the ADR home existed; there is no PR-merge gate to promote
+it through.
+-->
+
+## Context
+[Jorudan](https://www.jorudan.co.jp/) publishes no public transit API, and its
+site is fronted by a JavaScript-based bot check. A naive server-side `fetch()`
+of a route-search URL therefore returns an HTML stub (the bot-check page),
+not the rendered route data we need. We want to keep a personal commute board
+running as cheaply as possible for a single fixed route, which rules out
+standing infrastructure and recurring API fees.
+
+## Decision
+Implement a hand-rolled 3-step cookie flow against Jorudan's own endpoints,
+running on AWS Lambda (Node.js 22, ESM) in `src/index.mjs`. The handler walks
+the cookie-issuing endpoints to satisfy the bot check, then fetches and parses
+the server-rendered route HTML. The implementation hardens the two
+attacker-influenced surfaces it depends on: a `safeJoinUrl()` SSRF guard that
+constrains every derived request to the expected Jorudan host, and an
+`escapeRegExp()` ReDoS guard on values interpolated into parsing regexes.
+This is the cheapest way to keep the board working without a public API.
+
+## Rejected alternatives
+- **Headless browser (e.g. Puppeteer/Playwright on Lambda)** — would clear the
+  bot check by executing the page JavaScript, but the Chromium layer inflates
+  cold-start latency and per-invocation cost well beyond a plain HTTP scraper,
+  defeating the cheapest-board goal.
+- **A paid / third-party transit API** — no provider offers Jorudan-equivalent
+  route data for this commute, and a subscription reintroduces the recurring
+  cost this project exists to avoid.
+
+## Consequences
+- **Positive**: near-zero idle cost (Lambda scales to zero), no browser layer to
+  maintain, and a small dependency surface that is fast to cold-start.
+- **Negative (tight coupling to Jorudan's HTML/cookie contract)**: the scraper
+  is bound to Jorudan's server-rendered markup and cookie endpoints. Any change
+  to the bot check, the `set-uuid.cgi` cookie step, the
+  `<hr size="1" color="black">` section delimiter, or the `発着時間：` route
+  lookahead silently breaks parsing, with no upstream contract or version to
+  warn us. Recovery means re-reverse-engineering the live site.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -1,0 +1,9 @@
+# Architecture Decision Records
+
+Lifecycle: `Proposed → Accepted (on PR merge) → {Deprecated | Superseded | Rejected}`
+
+Do not hand-edit rows; this table is regenerated on each `x-recording-adr` run.
+
+| ID | Title | Status | applyTo | File |
+| --- | --- | --- | --- | --- |
+| 0001 | Jorudan 3-step cookie-flow scraper on AWS Lambda | Accepted | src/index.mjs | 0001-jorudan-cookie-flow-scraper.md |


### PR DESCRIPTION
## Summary
Stands up the ADR home so the `x-recording-adr` skill has a target directory to engage with. Creates `docs/adr/` with a MADR-Minimal template, a hand-seeded foundational ADR, and the index. The `CLAUDE.md` `adr-dir:` adoption marker is wired separately in #64.

## Changes
- Add `docs/adr/0000-template.md` — verbatim MADR-Minimal scaffold (`status`/`applyTo` frontmatter, five headings) with a comment noting `applyTo` is a local extension.
- Add `docs/adr/0001-jorudan-cookie-flow-scraper.md` — seed ADR (`status: Accepted`, `applyTo: src/index.mjs`) recording the 3-step cookie-flow scraper decision, two rejected alternatives, and a negative consequence; includes an in-file note that `Accepted` is a deliberate hand-seed.
- Add `docs/adr/INDEX.md` — `| ID | Title | Status | applyTo | File |` table, lifecycle legend, no-hand-edit note, and one data row for 0001.

## Verification
- `npm run lint` -> pass (eslint clean)
- `npm test` -> pass (50/50 tests, 0 fail)
- x-code-reviewer -> 0 Critical, 0 Warning (2 non-blocking Suggestions)
- Acceptance criteria (graded by independent subagent, ALL MET):
  - AC1 `test -f` all three files -> MET (exit 0)
  - AC2 frontmatter `status: Accepted` + `applyTo: src/index.mjs` -> MET
  - AC3 body names a rejected option and a negative consequence -> MET
  - AC4 grep for real AWS identifiers in docs/adr/ -> MET (no matches)
  - AC5 INDEX header row present + exactly one data row -> MET

Closes #62