### PR TITLE
fix(transit): restore Jorudan transit via jrd_uuid handshake and resolve npm audit vulnerabilities

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ CloudFront + S3 (Frontend) → API Gateway → Lambda → Jorudan
 - **API Gateway routes**: `GET /api/transit`, `GET /api/status`
 - **Region**: `ap-northeast-1`
 
-For the AWS topology diagram, the Jorudan 3-step cookie flow, HTML parsing rules, ReDoS/SSRF guards, API path normalization, and the full response schema, see [`docs/architecture.md`](./docs/architecture.md). The diagram source lives at [`docs/diagrams/lambda-function-transit-aws-architecture.drawio`](./docs/diagrams/lambda-function-transit-aws-architecture.drawio).
+For the AWS topology diagram, the Jorudan 6-hop `jrd_uuid` cookie handshake, HTML parsing rules, ReDoS/SSRF guards, API path normalization, and the full response schema, see [`docs/architecture.md`](./docs/architecture.md). The diagram source lives at [`docs/diagrams/lambda-function-transit-aws-architecture.drawio`](./docs/diagrams/lambda-function-transit-aws-architecture.drawio).
 
 ### Repository Layout
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,21 +14,29 @@ CloudFront + S3 (Frontend) → API Gateway → Lambda → Jorudan
 | Static hosting | S3 | Hosts the built Vite bundle. Sync target after `cd frontend && npm run build`. |
 | API | API Gateway (HTTP) | Routes `GET /api/transit` and `GET /api/status` to the Lambda function. |
 | Compute | AWS Lambda (Node.js 22, ESM) | Entry point: `src/index.mjs` → `handler(event, context)`. Region: `ap-northeast-1`. |
-| Upstream | Jorudan | Public Japanese transit search. Requires a 3-step cookie flow to bypass bot detection (see below). |
+| Upstream | Jorudan | Public Japanese transit search. Requires a 6-hop, cross-subdomain cookie handshake to bypass bot detection (see below). |
 
 The full AWS architecture diagram lives at [`diagrams/lambda-function-transit-aws-architecture.drawio`](./diagrams/lambda-function-transit-aws-architecture.drawio) (rendered at [`diagrams/lambda-function-transit-aws-architecture.png`](./diagrams/lambda-function-transit-aws-architecture.png)).
 
-## Jorudan Bot Detection — 3-Step Cookie Flow
+## Jorudan Bot Detection — 6-Hop `jrd_uuid` Cookie Handshake
 
-Jorudan fronts its site with CloudFront and a JavaScript-based bot check. A naive `fetch()` against the search URL receives an HTML stub instead of the transit results page, because the real URL is computed client-side after the bot check sets a cookie.
+Jorudan fronts its site with CloudFront and a JavaScript-based bot check. A naive `fetch()` against the search URL receives an HTML stub instead of the transit results page, because the real URL is computed client-side and gated behind a UUID-cookie handshake performed on a **separate subdomain** (`jid.jorudan.co.jp`).
 
-The Lambda handler emulates the browser flow:
+`performBotHandshake()` in `src/index.mjs` emulates the browser flow for each origin (one `CookieJar` and one overall budget per call):
 
-1. **Initial request** — fetch the transit search URL, parse the response, and read the redirect URL from `window.location.href` in the returned HTML.
-2. **Cookie collection** — follow `/webuser/set-uuid.cgi?url=...`, which responds with `Set-Cookie` headers carrying the bot-check token.
-3. **Authoritative fetch** — request the final URL with the collected cookies attached. The response is the rendered transit results HTML.
+1. **Initial request** — GET the `nori.cgi` search URL on `www.jorudan.co.jp`. The body is a JS redirect page; `extractJsRedirect()` reads the (single- or double-quoted) `window.location.href`, which is now an **absolute cross-host URL** to `https://jid.jorudan.co.jp/jrd_uuid/?returl=...`. (Fast-path: if this first response already contains the results marker `<hr size="1"`, it is returned directly.)
+2. **jid page** — GET the `jrd_uuid` page on `jid.jorudan.co.jp`. In a real browser its inline JS drives the next two AJAX calls; the handler derives those URLs directly from this page URL's querystring.
+3. **set_uuid** — GET `jid.../jrd_uuid/set_uuid.cgi?<returl...>` with browser-`fetch()`-equivalent AJAX headers (`Accept: */*`, `Referer` = the jid page, `Sec-Fetch-Site: same-origin`). Missing these headers returns **403** (`./error.html`). Responds with `Set-Cookie jrd_cuid` (`Domain=jid.jorudan.co.jp`, short `max-age`).
+4. **verify_uuid** — GET `jid.../jrd_uuid/verify_uuid.cgi?<returl...>` with the same AJAX headers and the `jrd_cuid` cookie. The **response body is the plaintext final URL** (`https://www.jorudan.co.jp/webuser/redirect2.cgi?url=...`) and it sets `Set-Cookie jrd_uuid` with `Domain=.jorudan.co.jp` (shared across subdomains).
+5. **redirect2** — GET `www.../webuser/redirect2.cgi?url=...` → `302` whose `Location` is the authoritative `nori.cgi` URL.
+6. **Authoritative fetch** — GET the final `nori.cgi` with the cookie jar. Because `jrd_uuid` is a parent-domain (`.jorudan.co.jp`) cookie it is sent to `www`; the jid-host-only `jrd_cuid` is not. The response is the rendered transit results HTML (verified by the `<hr size="1"` marker).
 
-If any step's redirect URL contains `//` or `://` in the path component, `safeJoinUrl()` rejects it (SSRF guard against attacker-controlled redirects).
+### Guards
+
+- **SSRF — `isAllowedUrl()`**: every hop's URL (and the plaintext `verify_uuid` body) is parsed with the WHATWG `URL` API and accepted only if it is `https:` and its exact `.hostname` is in the allowlist `{www.jorudan.co.jp, jid.jorudan.co.jp}` (with no embedded credentials). This rejects off-allowlist hosts, look-alike suffixes (`jorudan.co.jp.evil.com`), the bare apex, TLS downgrades (`http://169.254.169.254/...`), protocol-relative `//host`, and `data:`/`javascript:`/`file:`/`ftp:` schemes.
+- **Cookies — Domain-attribute scoping**: a `CookieJar` (built on `Headers.getSetCookie()`) honours each `Set-Cookie` `Domain` — host-only when absent, shared only when `Domain=.jorudan.co.jp` — so no jid-scoped cookie leaks to `www` and vice versa.
+- **Timeout budget**: each hop is capped at `PER_HOP_TIMEOUT_MS` (2.5s) and the whole per-origin chain at `OVERALL_BUDGET_MS` (7s), via `AbortSignal.timeout(min(perHop, remaining))`, keeping the 6-hop chain inside the Lambda `Timeout` (15s). The 3 origins run concurrently via `Promise.allSettled`, so one origin failing still returns the others (HTTP 200); all failing returns 500.
+- **ReDoS**: `extractJsRedirect()` uses a non-backtracking negated character class (`[^'"]+`), and dynamic substrings used in route-parsing regexes are escaped via `escapeRegExp()`.
 
 ## HTML Parsing
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -52,13 +52,13 @@
       "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.28.6.tgz",
-      "integrity": "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -67,9 +67,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.6.tgz",
-      "integrity": "sha512-2lfu57JtzctfIrcGMz992hyLlByuzgIk58+hhGCxjKZ3rWI82NnVLjXcaTqkI2NvlcvOskZaiZ5kjUALo3Lpxg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -77,21 +77,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.6.tgz",
-      "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/generator": "^7.28.6",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -108,14 +108,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.6.tgz",
-      "integrity": "sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -125,14 +125,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -142,9 +142,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -152,29 +152,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -194,9 +194,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -204,9 +204,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -214,9 +214,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -224,27 +224,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.6.tgz",
-      "integrity": "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.6"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -296,33 +296,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.6.tgz",
-      "integrity": "sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/generator": "^7.28.6",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.6",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -330,14 +330,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.6.tgz",
-      "integrity": "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2202,13 +2202,16 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.17",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.17.tgz",
-      "integrity": "sha512-agD0MgJFUP/4nvjqzIB29zRPUuCF7Ge6mEv9s8dHrtYD7QWXRcx75rOADE/d5ah1NI+0vkDl0yorDd5U852IQQ==",
+      "version": "2.10.38",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
+      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/brace-expansion": {
@@ -2223,9 +2226,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
       "dev": true,
       "funding": [
         {
@@ -2243,11 +2246,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2267,9 +2270,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001765",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001765.tgz",
-      "integrity": "sha512-LWcNtSyZrakjECqmpP4qdg0MMGdN368D7X8XvvAqOcqMv0RxnlqVKZl2V6/mBR68oYMxOZPLw/gO7DuisMHUvQ==",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "dev": true,
       "funding": [
         {
@@ -2448,9 +2451,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.267",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
-      "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
+      "version": "1.5.376",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.376.tgz",
+      "integrity": "sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==",
       "dev": true,
       "license": "ISC"
     },
@@ -3023,10 +3026,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -3246,11 +3259,14 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "version": "2.0.48",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
+      "integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/nwsapi": {
       "version": "2.2.23",
@@ -3892,9 +3908,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1002,10 +1002,20 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -12,7 +12,9 @@ const JORUDAN_ORIGINS = [
   { origin: '神谷町',       url: `${JORUDAN_URL_PREFIX}%E7%A5%9E%E8%B0%B7%E7%94%BA${JORUDAN_URL_SUFFIX}` },
   { origin: '麻布十番',     url: `${JORUDAN_URL_PREFIX}%E9%BA%BB%E5%B8%83%E5%8D%81%E7%95%AA${JORUDAN_URL_SUFFIX}` },
 ];
-const REQUEST_TIMEOUT_MS = 3000;
+const PER_HOP_TIMEOUT_MS = 2500;   // per-fetch timeout for a single hop
+const OVERALL_BUDGET_MS = 7000;    // total budget for one origin's full handshake
+const ALLOWED_HOSTS = new Set(['www.jorudan.co.jp', 'jid.jorudan.co.jp']);
 const MIN_EXPECTED_BLOCKS = 3;
 const TARGET_BLOCK_INDEX = 2;  // Third block contains route information
 const MAX_CANDIDATES = 2;  // Maximum number of transit candidates to return
@@ -92,140 +94,211 @@ const BROWSER_HEADERS = {
 };
 
 /**
- * Extract redirect URL from JavaScript redirect page.
- * Only single-leading-slash relative paths are allowed; absolute URLs and
- * non-HTTP schemes (data:, javascript:, ftp:, file:, ...) return null so the
- * caller treats them as "no redirect" instead of feeding them into
- * safeJoinUrl(), which throws on `://`.
- * @param {string} body - HTML body containing JS redirect
- * @returns {string|null} Redirect path (relative) or null
+ * Extract the redirect target from a Jorudan JavaScript redirect page.
+ * Handles both single- and double-quoted `window.location.href` assignments and
+ * returns the raw URL string (which is now a legitimate absolute cross-host URL
+ * to jid.jorudan.co.jp). Host/scheme validation is deferred to isAllowedUrl().
+ * The negated character class `[^'"]+` cannot backtrack, so this is ReDoS-safe.
+ * @param {string} body - HTML body containing the JS redirect
+ * @returns {string|null} Redirect URL string or null
  */
-export function extractRedirectUrl(body) {
-  const match = body.match(/window\.location\.href="([^"]+)"/);
+export function extractJsRedirect(body) {
+  const match = body.match(/window\.location\.href\s*=\s*(['"])([^'"]+)\1/);
   if (!match) return null;
-  const candidate = match[1].trim();
-  if (!/^\/(?!\/)/.test(candidate)) return null;
-  return candidate;
+  return match[2].trim() || null;
 }
 
 /**
- * Safely join base URL with path, preventing SSRF via protocol injection
- * @param {string} base - Base URL (e.g., 'https://www.jorudan.co.jp')
- * @param {string} path - Path to join
- * @returns {string} Full URL
- * @throws {Error} If path contains protocol or attempts domain escape
+ * SSRF guard: resolve a URL and accept it only if it targets an allowlisted
+ * Jorudan host over https. Single chokepoint called before every hop, and on
+ * the plaintext verify_uuid result. Rejects non-https schemes (data:,
+ * javascript:, file:, ftp:, protocol-relative //), credentials in the URL, and
+ * any host outside ALLOWED_HOSTS (exact hostname match — no substring/suffix).
+ * @param {string} rawUrl - URL or relative reference to validate
+ * @param {string} [baseUrl] - Base for resolving a relative reference
+ * @returns {URL|null} Parsed URL when allowed, otherwise null
  */
-function safeJoinUrl(base, path) {
-  if (path.startsWith('//') || path.includes('://')) {
-    throw new Error('Invalid redirect path detected');
+export function isAllowedUrl(rawUrl, baseUrl) {
+  let u;
+  try {
+    u = baseUrl ? new URL(rawUrl, baseUrl) : new URL(rawUrl);
+  } catch {
+    return null;
   }
-  return `${base}${path.startsWith('/') ? '' : '/'}${path}`;
+  if (u.protocol !== 'https:') return null;
+  if (u.username || u.password) return null;
+  if (!ALLOWED_HOSTS.has(u.hostname)) return null;
+  return u;
 }
 
 /**
- * Extract cookies from Set-Cookie headers
- * @param {Headers} headers - Response headers
- * @returns {string} Cookie string for subsequent requests
+ * Split a folded Set-Cookie header string into individual cookie lines.
+ * Fallback for environments (and test mocks) where Headers.getSetCookie() is
+ * unavailable; the lookahead avoids splitting on commas inside Expires dates.
+ * @param {string|null} setCookieHeader - Raw set-cookie header value
+ * @returns {string[]} Individual Set-Cookie strings
  */
-function extractCookies(headers) {
-  const setCookieHeader = headers.get('set-cookie');
-  if (!setCookieHeader) return '';
-
-  return setCookieHeader
-    .split(/,(?=\s*\w+=)/)
-    .map(part => part.split(';')[0].trim())
-    .filter(Boolean)
-    .join('; ');
+function legacySplitSetCookie(setCookieHeader) {
+  if (!setCookieHeader) return [];
+  return setCookieHeader.split(/,(?=\s*\w+=)/).map(s => s.trim()).filter(Boolean);
 }
 
 /**
- * Fetch URL with cookie handling for Jorudan's UUID redirect
- * @param {string} url - URL to fetch
- * @returns {Promise<string>} HTML body
+ * Minimal cookie jar with Domain-attribute scoping (browser-faithful).
+ * A cookie with `Domain=.jorudan.co.jp` is shared across allowed subdomains
+ * (so jid-set jrd_uuid reaches the final www request); a cookie with no Domain
+ * is host-only (so jid-scoped jrd_cuid never leaks to www).
  */
-async function fetchTransitPage(url) {
-  // Step 1: Initial request to get redirect page
-  const response1 = await fetch(url, {
-    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-    headers: BROWSER_HEADERS,
-    redirect: 'manual',
-  });
+class CookieJar {
+  #byHost = new Map();    // exact host -> Map(name -> value)
+  #byDomain = new Map();  // registrable domain (no leading dot) -> Map(name -> value)
 
-  const body1 = await response1.text();
-  let cookies = extractCookies(response1.headers);
-
-  // Check if we got a JavaScript redirect page
-  const redirectPath = extractRedirectUrl(body1);
-  if (!redirectPath) {
-    // No redirect needed, check if we have valid data
-    if (body1.includes('<hr size="1"')) {
-      return body1;
-    }
-    throw new Error('Unexpected response: no redirect and no transit data');
-  }
-
-  // Step 2: Follow the UUID redirect to get cookie
-  const redirectUrl = safeJoinUrl(JORUDAN_BASE_URL, redirectPath);
-  const response2 = await fetch(redirectUrl, {
-    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-    headers: {
-      ...BROWSER_HEADERS,
-      ...(cookies && { Cookie: cookies }),
-    },
-    redirect: 'manual',
-  });
-
-  // Collect cookies from redirect response
-  const newCookies = extractCookies(response2.headers);
-  if (newCookies) {
-    cookies = cookies ? `${cookies}; ${newCookies}` : newCookies;
-  }
-
-  // Step 3: Follow Location header if present, or extract final URL
-  let finalUrl = response2.headers.get('location');
-  if (finalUrl) {
-    if (finalUrl.startsWith('http')) {
-      const parsedUrl = new URL(finalUrl);
-      if (parsedUrl.origin !== JORUDAN_BASE_URL) {
-        throw new Error('Invalid redirect: unexpected domain');
+  store(headers, requestHost) {
+    const lines = headers.getSetCookie?.() ?? legacySplitSetCookie(headers.get?.('set-cookie'));
+    for (const line of lines) {
+      if (!line) continue;
+      const [pair, ...attrs] = line.split(';');
+      const eq = pair.indexOf('=');
+      if (eq <= 0) continue;
+      const name = pair.slice(0, eq).trim();
+      const value = pair.slice(eq + 1).trim();
+      if (!name) continue;
+      let domain = null;
+      for (const attr of attrs) {
+        const ai = attr.indexOf('=');
+        if (ai > 0 && attr.slice(0, ai).trim().toLowerCase() === 'domain') {
+          domain = attr.slice(ai + 1).trim().replace(/^\./, '').toLowerCase();
+        }
       }
-    } else {
-      finalUrl = safeJoinUrl(JORUDAN_BASE_URL, finalUrl);
+      const bucket = domain ? this.#byDomain : this.#byHost;
+      const key = domain || requestHost.toLowerCase();
+      if (!bucket.has(key)) bucket.set(key, new Map());
+      bucket.get(key).set(name, value);
     }
   }
 
-  // If no location header, the redirect URL contains the final URL in query param
-  if (!finalUrl) {
-    const urlParam = new URL(redirectUrl).searchParams.get('url');
-    if (urlParam) {
-      finalUrl = safeJoinUrl(JORUDAN_BASE_URL, decodeURIComponent(urlParam));
+  headerFor(host) {
+    const h = host.toLowerCase();
+    const merged = new Map();
+    for (const [domain, cookies] of this.#byDomain) {
+      if (h === domain || h.endsWith(`.${domain}`)) {
+        for (const [n, v] of cookies) merged.set(n, v);
+      }
     }
+    const hostCookies = this.#byHost.get(h);
+    if (hostCookies) for (const [n, v] of hostCookies) merged.set(n, v);
+    return [...merged].map(([n, v]) => `${n}=${v}`).join('; ');
   }
+}
 
-  if (!finalUrl) {
-    throw new Error('Could not determine final URL after redirect');
-  }
+/**
+ * Headers that mimic the browser's `fetch()` AJAX calls to set_uuid/verify_uuid.
+ * Jorudan returns 403 (body "./error.html") without these.
+ * @param {string} refererUrl - The jid page URL that "issued" the AJAX call
+ * @returns {Object} Header map
+ */
+function buildAjaxHeaders(refererUrl) {
+  return {
+    'User-Agent': BROWSER_HEADERS['User-Agent'],
+    'Accept': '*/*',
+    'Accept-Language': BROWSER_HEADERS['Accept-Language'],
+    'Referer': refererUrl,
+    'Sec-Fetch-Site': 'same-origin',
+    'Sec-Fetch-Mode': 'cors',
+    'Sec-Fetch-Dest': 'empty',
+  };
+}
 
-  // Step 4: Fetch the actual transit page with cookies
-  const response3 = await fetch(finalUrl, {
-    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-    headers: {
-      ...BROWSER_HEADERS,
-      ...(cookies && { Cookie: cookies }),
-    },
+/**
+ * fetch() bounded by both a per-hop timeout and the remaining origin budget.
+ * @param {string} url - URL to fetch
+ * @param {Object} opts - { headers, redirect }
+ * @param {number} deadline - Date.now() epoch ms after which the origin budget is spent
+ * @returns {Promise<Response>}
+ */
+function fetchWithBudget(url, { headers, redirect = 'manual' }, deadline) {
+  const remaining = deadline - Date.now();
+  if (remaining <= 0) throw new Error('Origin budget exhausted');
+  return fetch(url, {
+    headers,
+    redirect,
+    signal: AbortSignal.timeout(Math.min(PER_HOP_TIMEOUT_MS, remaining)),
   });
+}
 
-  if (!response3.ok) {
-    throw new Error(`HTTP error! status: ${response3.status}`);
+/**
+ * Run Jorudan's jrd_uuid bot-check handshake for one origin and return the
+ * final transit HTML. Six hops: nori -> jid page -> set_uuid -> verify_uuid ->
+ * redirect2 -> nori. Every hop's URL is host-validated; cookies are accumulated
+ * with Domain-attribute scoping; the whole chain is bounded by OVERALL_BUDGET_MS.
+ * @param {string} originUrl - The initial nori.cgi search URL
+ * @returns {Promise<string>} Transit results HTML
+ */
+async function performBotHandshake(originUrl) {
+  const jar = new CookieJar();
+  const deadline = Date.now() + OVERALL_BUDGET_MS;
+
+  const get = async (urlObj, headers, redirect) => {
+    const cookie = jar.headerFor(urlObj.hostname);
+    const res = await fetchWithBudget(
+      urlObj.href,
+      { headers: cookie ? { ...headers, Cookie: cookie } : headers, redirect },
+      deadline,
+    );
+    jar.store(res.headers, urlObj.hostname);
+    return res;
+  };
+
+  // Hop 1: initial nori.cgi request
+  const origin = isAllowedUrl(originUrl);
+  if (!origin) throw new Error('Origin URL not allowed');
+  const r1 = await get(origin, BROWSER_HEADERS, 'manual');
+  const body1 = await r1.text();
+
+  // Fast path: already authorized (warm cookies, or a direct results page)
+  if (body1.includes('<hr size="1"')) return body1;
+
+  const jidRaw = extractJsRedirect(body1);
+  const jidUrl = jidRaw && isAllowedUrl(jidRaw, origin.href);
+  if (!jidUrl) throw new Error('Bot check: no valid jid redirect');
+
+  // Hop 2: jid page (the JS here drives the AJAX handshake in a real browser)
+  const r2 = await get(jidUrl, BROWSER_HEADERS, 'manual');
+  await r2.text();
+
+  // The AJAX endpoints share the jid page's querystring (?returl=...)
+  const setUrl = isAllowedUrl(`./set_uuid.cgi${jidUrl.search}`, jidUrl.href);
+  const verifyUrl = isAllowedUrl(`./verify_uuid.cgi${jidUrl.search}`, jidUrl.href);
+  if (!setUrl || !verifyUrl) throw new Error('Bot check: derived UUID URL not allowed');
+  const ajaxHeaders = buildAjaxHeaders(jidUrl.href);
+
+  // Hop 3: set_uuid.cgi -> Set-Cookie jrd_cuid (jid-scoped)
+  const r3 = await get(setUrl, ajaxHeaders, 'manual');
+  if (!r3.ok) throw new Error(`set_uuid failed: ${r3.status}`);
+
+  // Hop 4: verify_uuid.cgi -> plaintext final redirect URL (and Set-Cookie jrd_uuid)
+  const r4 = await get(verifyUrl, ajaxHeaders, 'manual');
+  if (!r4.ok) throw new Error(`verify_uuid failed: ${r4.status}`);
+  const finalRaw = (await r4.text()).trim();
+  if (!finalRaw || finalRaw.length > 2048 || /\s/.test(finalRaw)) {
+    throw new Error('Bot check: invalid verify_uuid body');
   }
+  const redirect2Url = isAllowedUrl(finalRaw);
+  if (!redirect2Url) throw new Error('Bot check: verify_uuid result not allowed');
 
-  const body = await response3.text();
+  // Hop 5: redirect2.cgi -> 302 to nori.cgi
+  const r5 = await get(redirect2Url, BROWSER_HEADERS, 'manual');
+  const location = r5.headers.get('location');
+  const transitUrl = location && isAllowedUrl(location, redirect2Url.href);
+  if (!transitUrl) throw new Error('Bot check: invalid post-redirect location');
 
-  // Verify we got actual transit data
+  // Hop 6: final transit page (carries jrd_uuid via Domain=.jorudan.co.jp)
+  const r6 = await get(transitUrl, BROWSER_HEADERS, 'manual');
+  if (!r6.ok) throw new Error(`HTTP error! status: ${r6.status}`);
+  const body = await r6.text();
   if (!body.includes('<hr size="1"')) {
     throw new Error('Failed to get transit data after cookie flow');
   }
-
   return body;
 }
 
@@ -278,7 +351,7 @@ export async function handler(event, _context) {
   try {
     const results = await Promise.allSettled(
       JORUDAN_ORIGINS.map(({ origin, url }) =>
-        fetchTransitPage(url).then(body => {
+        performBotHandshake(url).then(body => {
           const blocks = body.split(/<hr size="1" color="black"\s*\/?>/i);
           if (blocks.length < MIN_EXPECTED_BLOCKS) {
             throw new Error(`Unexpected HTML structure: insufficient blocks (got ${blocks.length})`);

--- a/template.yml
+++ b/template.yml
@@ -37,7 +37,7 @@ Resources:
       CodeUri: ./src
       Description: Lambda Function of Roppongi-itchome To TsuTsujigaoka
       MemorySize: 128
-      Timeout: 10
+      Timeout: 15
       Handler: index.handler
       Runtime: nodejs22.x
       Architectures:

--- a/tests/handler.test.mjs
+++ b/tests/handler.test.mjs
@@ -1,6 +1,6 @@
 import { describe, it, mock } from 'node:test';
 import assert from 'node:assert';
-import { getSummary, getRoute, splitRoutes, handler, extractRedirectUrl } from '../src/index.mjs';
+import { getSummary, getRoute, splitRoutes, handler, extractJsRedirect, isAllowedUrl } from '../src/index.mjs';
 
 // Mock HTML block matching real Jorudan format (■ for terminal, ◇ for transfer stations)
 const mockBlock = `発着時間：06:30～08:45\r\n所要時間：2時間15分\r\n乗換回数：2回\r\n\r\n■六本木一丁目    1番線発\r\n｜ 　東京メトロ南北線(浦和美園行)   3.1km\r\n｜06:30-06:36［6分］\r\n｜178円\r\n◇永田町    3番線着・1番線発 ［乗換4分+待ち4分］\r\n｜ 　東京メトロ半蔵門線(中央林間行)   5.7km\r\n｜06:44-06:53［9分］\r\n｜ ↓\r\n◇渋谷    1番線着・1番線発 ［乗換6分+待ち4分］\r\n｜ 　京王井の頭線(吉祥寺行)   12.5km\r\n｜07:03-07:20［17分］\r\n｜230円\r\n■つつじヶ丘（東京）    1・2番線着`;
@@ -159,64 +159,90 @@ describe('splitRoutes', () => {
   });
 });
 
-describe('extractRedirectUrl scheme validation', () => {
-  function bodyWith(href) {
-    return `<html><script>window.location.href="${href}"</script></html>`;
-  }
+describe('extractJsRedirect', () => {
+  const JID = 'https://jid.jorudan.co.jp/jrd_uuid/?returl=abc';
 
-  it('should accept a single-leading-slash relative path', () => {
-    const result = extractRedirectUrl(bodyWith('/webuser/set-uuid.cgi?url=https%3A%2F%2Fwww.jorudan.co.jp%2Fnorikae%2Fcgi%2Fnori.cgi'));
-    assert.strictEqual(result, '/webuser/set-uuid.cgi?url=https%3A%2F%2Fwww.jorudan.co.jp%2Fnorikae%2Fcgi%2Fnori.cgi');
+  it('should extract a single-quoted absolute redirect (the new Jorudan form)', () => {
+    const body = `<script>function rdr(){window.location.href='${JID}';}rdr();</script>`;
+    assert.strictEqual(extractJsRedirect(body), JID);
   });
 
-  it('should accept a relative path with query string', () => {
-    const result = extractRedirectUrl(bodyWith('/path/with/?query=v&other=v'));
-    assert.strictEqual(result, '/path/with/?query=v&other=v');
+  it('should extract a double-quoted redirect (defensive, in case Jorudan reverts)', () => {
+    const body = `<script>window.location.href="${JID}"</script>`;
+    assert.strictEqual(extractJsRedirect(body), JID);
   });
 
-  it('should reject absolute https:// URLs (downstream safeJoinUrl would throw)', () => {
-    const result = extractRedirectUrl(bodyWith('https://www.jorudan.co.jp/norikae/'));
-    assert.strictEqual(result, null);
+  it('should extract a relative redirect string verbatim (validation deferred)', () => {
+    const body = `<script>window.location.href='/webuser/set-uuid.cgi?url=/x'</script>`;
+    assert.strictEqual(extractJsRedirect(body), '/webuser/set-uuid.cgi?url=/x');
   });
 
-  it('should reject data: URIs', () => {
-    const result = extractRedirectUrl(bodyWith('data:text/html,<script>alert(1)</script>'));
-    assert.strictEqual(result, null);
+  it('should return null when no window.location.href is present', () => {
+    assert.strictEqual(extractJsRedirect('<html>no redirect here</html>'), null);
   });
 
-  it('should reject javascript: URIs', () => {
-    const result = extractRedirectUrl(bodyWith('javascript:alert(1)'));
-    assert.strictEqual(result, null);
+  it('should be ReDoS-safe on a pathological unterminated-quote body', () => {
+    const body = `<script>window.location.href='${'a'.repeat(100000)}`;
+    const start = process.hrtime.bigint();
+    const result = extractJsRedirect(body);
+    const elapsedMs = Number(process.hrtime.bigint() - start) / 1e6;
+    assert.strictEqual(result, null, 'unterminated quote should not match');
+    assert.ok(elapsedMs < 100, `should return quickly (took ${elapsedMs}ms)`);
+  });
+});
+
+describe('isAllowedUrl SSRF guard', () => {
+  const BASE = 'https://www.jorudan.co.jp/norikae/cgi/nori.cgi';
+
+  it('should accept https www.jorudan.co.jp', () => {
+    assert.strictEqual(isAllowedUrl('https://www.jorudan.co.jp/x')?.hostname, 'www.jorudan.co.jp');
   });
 
-  it('should reject mixed-case JavaScript: URIs', () => {
-    const result = extractRedirectUrl(bodyWith('JavaScript:alert(1)'));
-    assert.strictEqual(result, null);
+  it('should accept https jid.jorudan.co.jp', () => {
+    assert.strictEqual(isAllowedUrl('https://jid.jorudan.co.jp/jrd_uuid/')?.hostname, 'jid.jorudan.co.jp');
   });
 
-  it('should reject ftp:// URIs', () => {
-    const result = extractRedirectUrl(bodyWith('ftp://attacker.example/'));
-    assert.strictEqual(result, null);
+  it('should resolve and accept a relative reference against an allowed base', () => {
+    assert.strictEqual(isAllowedUrl('./set_uuid.cgi?returl=abc', 'https://jid.jorudan.co.jp/jrd_uuid/?returl=abc')?.hostname, 'jid.jorudan.co.jp');
   });
 
-  it('should reject file:// URIs', () => {
-    const result = extractRedirectUrl(bodyWith('file:///etc/passwd'));
-    assert.strictEqual(result, null);
+  it('should reject an off-allowlist host', () => {
+    assert.strictEqual(isAllowedUrl('https://evil.com/steal'), null);
   });
 
-  it('should reject javascript: URIs even with leading whitespace (after trim)', () => {
-    const result = extractRedirectUrl(bodyWith('  javascript:alert(1)'));
-    assert.strictEqual(result, null);
+  it('should reject a look-alike suffix host (exact match, not substring)', () => {
+    assert.strictEqual(isAllowedUrl('https://jorudan.co.jp.evil.com/'), null);
+    assert.strictEqual(isAllowedUrl('https://www.jorudan.co.jp.evil.com/'), null);
   });
 
-  it('should reject protocol-relative // URIs', () => {
-    const result = extractRedirectUrl(bodyWith('//attacker.example/path'));
-    assert.strictEqual(result, null);
+  it('should reject the bare apex jorudan.co.jp (not in allowlist)', () => {
+    assert.strictEqual(isAllowedUrl('https://jorudan.co.jp/'), null);
   });
 
-  it('should return null when window.location.href is missing', () => {
-    const result = extractRedirectUrl('<html>no redirect here</html>');
-    assert.strictEqual(result, null);
+  it('should reject http (TLS downgrade), including the metadata IP', () => {
+    assert.strictEqual(isAllowedUrl('http://www.jorudan.co.jp/'), null);
+    assert.strictEqual(isAllowedUrl('http://169.254.169.254/latest/meta-data/'), null);
+  });
+
+  it('should reject credentials embedded in the URL', () => {
+    assert.strictEqual(isAllowedUrl('https://www.jorudan.co.jp@evil.com/'), null);
+    assert.strictEqual(isAllowedUrl('https://user:pass@www.jorudan.co.jp/'), null);
+  });
+
+  it('should reject data:, javascript:, file:, ftp: schemes', () => {
+    assert.strictEqual(isAllowedUrl('data:text/html,<script>alert(1)</script>'), null);
+    assert.strictEqual(isAllowedUrl('javascript:alert(1)'), null);
+    assert.strictEqual(isAllowedUrl('JavaScript:alert(1)'), null);
+    assert.strictEqual(isAllowedUrl('file:///etc/passwd'), null);
+    assert.strictEqual(isAllowedUrl('ftp://attacker.example/'), null);
+  });
+
+  it('should reject protocol-relative // references resolved off-allowlist', () => {
+    assert.strictEqual(isAllowedUrl('//evil.com/path', BASE), null);
+  });
+
+  it('should return null on unparseable input', () => {
+    assert.strictEqual(isAllowedUrl('not a url'), null);
   });
 });
 
@@ -382,6 +408,107 @@ describe('handler', () => {
       assert.strictEqual(body.routes[0].origin, '六本木一丁目');
       assert.strictEqual(body.routes[1].origin, '神谷町');
       assert.strictEqual(body.routes[2].origin, '麻布十番');
+    });
+  });
+});
+
+describe('handler — full jrd_uuid handshake (URL-keyed cookie-stateful router mock)', () => {
+  const JID = 'https://jid.jorudan.co.jp/jrd_uuid/?returl=https%3A%2F%2Fwww.jorudan.co.jp%2Fwebuser%2Fredirect2.cgi%3Furl%3Dx';
+  const REDIRECT2 = 'https://www.jorudan.co.jp/webuser/redirect2.cgi?url=%2Fnorikae%2Fcgi%2Fnori.cgi%3Ffinal%3D1';
+  const ROPPONGI_EKI1 = '%E5%85%AD%E6%9C%AC%E6%9C%A8'; // unique to the 六本木一丁目 origin
+  const redirectPage = `<!DOCTYPE html><script>function rdr(){window.location.href='${JID}';}rdr();</script>`;
+  const transitHtml = `block0<hr size="1" color="black" />block1<hr size="1" color="black" />${mockBlock}<hr size="1" color="black" />block3`;
+
+  function res({ status = 200, body = '', setCookie = [], location = null }) {
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      headers: {
+        get: (k) => (k.toLowerCase() === 'location' ? location : null),
+        getSetCookie: () => setCookie,
+      },
+      text: async () => body,
+    };
+  }
+
+  function makeRouter(calls, opts = {}) {
+    const verifyBody = opts.verifyBody ?? REDIRECT2;
+    return mock.fn(async (url, init = {}) => {
+      const cookie = (init.headers && init.headers.Cookie) || '';
+      calls.push({ url, headers: init.headers || {} });
+      if (url.includes('set_uuid.cgi')) {
+        return res({ setCookie: ['jrd_cuid=CUID;path=/jrd_uuid/;max-age=30;Domain=jid.jorudan.co.jp;Secure;HttpOnly'] });
+      }
+      if (url.includes('verify_uuid.cgi')) {
+        if (!cookie.includes('jrd_cuid')) return res({ body: './error.html' });
+        return res({ body: verifyBody, setCookie: ['jrd_uuid=UUID;path=/;max-age=31536000;Domain=.jorudan.co.jp;Secure;HttpOnly'] });
+      }
+      if (url.includes('/jrd_uuid/')) return res({ body: '<html>jid page</html>' }); // hop 2
+      if (url.includes('redirect2.cgi')) return res({ status: 302, location: '/norikae/cgi/nori.cgi?final=1' });
+      // nori.cgi: hop 1 (no jrd_uuid) returns the redirect page; hop 6 (jrd_uuid present) returns transit data
+      if (opts.failOrigin && url.includes(opts.failOrigin) && !cookie.includes('jrd_uuid')) {
+        return res({ body: 'broken: no redirect and no transit data' });
+      }
+      return cookie.includes('jrd_uuid') ? res({ body: transitHtml }) : res({ body: redirectPage });
+    });
+  }
+
+  async function withRouter(opts, testFn) {
+    const calls = [];
+    const original = globalThis.fetch;
+    globalThis.fetch = makeRouter(calls, opts);
+    try {
+      return await testFn(calls);
+    } finally {
+      globalThis.fetch = original;
+    }
+  }
+
+  it('completes the 6-hop flow and returns 200 with 3 origins', async () => {
+    await withRouter({}, async () => {
+      const result = await handler({ path: '/transit' }, {});
+      assert.strictEqual(result.statusCode, 200);
+      const data = JSON.parse(result.body);
+      assert.strictEqual(data.routes.length, 3, 'all 3 origins should succeed');
+      assert.ok(data.routes[0].transfers.length > 0, 'should have parsed transfers');
+    });
+  });
+
+  it('sends AJAX headers (Accept */*, Sec-Fetch-Site, jid Referer) to set_uuid', async () => {
+    await withRouter({}, async (calls) => {
+      await handler({ path: '/transit' }, {});
+      const ajaxCall = calls.find(c => c.url.includes('set_uuid.cgi'));
+      assert.ok(ajaxCall, 'set_uuid.cgi should be called');
+      assert.strictEqual(ajaxCall.headers.Accept, '*/*');
+      assert.strictEqual(ajaxCall.headers['Sec-Fetch-Site'], 'same-origin');
+      assert.ok(ajaxCall.headers.Referer.includes('jid.jorudan.co.jp'), 'Referer should be the jid page');
+    });
+  });
+
+  it('sends domain-scoped jrd_uuid to the final www request but never the jid-only jrd_cuid', async () => {
+    await withRouter({}, async (calls) => {
+      await handler({ path: '/transit' }, {});
+      const finalCall = calls.find(c => c.url.includes('nori.cgi?final=1'));
+      assert.ok(finalCall, 'final nori.cgi should be called');
+      assert.ok(finalCall.headers.Cookie.includes('jrd_uuid'), 'shared parent-domain cookie should reach www');
+      assert.ok(!finalCall.headers.Cookie.includes('jrd_cuid'), 'jid-host-scoped cookie must not leak to www');
+    });
+  });
+
+  it('returns 200 with the surviving origins when one origin fails (partial success)', async () => {
+    await withRouter({ failOrigin: ROPPONGI_EKI1 }, async () => {
+      const result = await handler({ path: '/transit' }, {});
+      assert.strictEqual(result.statusCode, 200);
+      const data = JSON.parse(result.body);
+      assert.strictEqual(data.routes.length, 2, 'two origins should still succeed');
+      assert.ok(!data.routes.some(r => r.origin === '六本木一丁目'), 'failed origin should be absent');
+    });
+  });
+
+  it('rejects an off-allowlist verify_uuid result (SSRF to metadata IP) -> 500', async () => {
+    await withRouter({ verifyBody: 'http://169.254.169.254/latest/meta-data/' }, async () => {
+      const result = await handler({ path: '/transit' }, {});
+      assert.strictEqual(result.statusCode, 500, 'metadata-IP final URL must be rejected at every origin');
     });
   });
 });


### PR DESCRIPTION
## Summary

Jorudan replaced its single-host JS-redirect bot check with a 6-hop, cross-subdomain `jrd_uuid` AJAX handshake, which broke the transit scraper in both production and local (every origin failed with "no redirect and no transit data", the handler returned 500, and the dashboard showed "Failed to load transit information"). This PR rewrites the cookie flow in `src/index.mjs` to emulate the new handshake and hardens the SSRF/cookie/timeout handling. It also carries the earlier npm-audit fix (dev-dependency bumps) developed on the same branch. Verified end-to-end against live Jorudan (200 with 3 origins) and via a Playwright browser check of the recovered dashboard.

## Changes

- Rewrite the Jorudan cookie flow: replace `extractRedirectUrl`/`safeJoinUrl`/`extractCookies`/`fetchTransitPage` with `extractJsRedirect`, `isAllowedUrl`, a `CookieJar`, `buildAjaxHeaders`, `fetchWithBudget`, and the 6-hop `performBotHandshake` (nori -> jid page -> set_uuid -> verify_uuid -> redirect2 -> nori).
- SSRF: single `isAllowedUrl` chokepoint enforcing an exact host allowlist `{www,jid}.jorudan.co.jp` + `https:` pin on every hop and on the `verify_uuid` plaintext result.
- Cookies: Domain-attribute-scoped `CookieJar` (built on `Headers.getSetCookie()`) so the parent-domain `jrd_uuid` reaches the final www request while the jid-scoped `jrd_cuid` does not leak.
- Timeouts: 2.5s per hop + 7s per-origin budget via `AbortSignal`; bump Lambda `Timeout` 10 -> 15 for headroom.
- Tests: new `extractJsRedirect` and `isAllowedUrl` suites, a URL-keyed cookie-stateful 6-hop router mock, plus SSRF / partial-failure / ReDoS cases (backend 60/60, frontend 32/32).
- Docs: update `docs/architecture.md` to the 6-hop flow and the `CLAUDE.md` pointer.
- Deps: resolve npm audit vulnerabilities (js-yaml, vite, @babel/core via lockfile updates; dev-dependencies only).