### PR TITLE
docs(adr): scaffold docs/adr with template, seed ADR, and index

### DIFF
--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,20 @@
+---
+status: Proposed
+applyTo: <repo-relative glob>
+---
+
+<!-- applyTo is a local extension to MADR-Minimal (not a standard MADR field): it declares the blast radius the decision governs. -->
+
+# NNNN. <Title>
+
+## Status
+Proposed
+
+## Context
+<the forces and the problem to solve>
+
+## Decision
+<the chosen option and why>
+
+## Consequences
+<positive and negative results; name at least one negative>

--- a/docs/adr/0001-jorudan-cookie-flow-scraper.md
+++ b/docs/adr/0001-jorudan-cookie-flow-scraper.md
@@ -1,0 +1,51 @@
+---
+status: Accepted
+applyTo: src/index.mjs
+---
+
+<!-- applyTo is a local extension to MADR-Minimal (not a standard MADR field): it declares the blast radius this decision governs. -->
+<!-- status: Accepted here is a deliberate hand-seed of an already-live decision, deviating from the x-recording-adr skill's Proposed-only automated-write rule; a normal ADR is born Proposed and promoted to Accepted on PR merge. -->
+
+# 0001. Jorudan cookie-flow scraper on AWS Lambda
+
+## Status
+Accepted
+
+## Context
+The dashboard needs train transit information for a fixed commute route from
+[Jorudan](https://www.jorudan.co.jp/), a Japanese transit search service.
+Jorudan publishes no public API and fronts its site with a JavaScript-based
+bot check, so a naive `fetch()` of a route URL returns an HTML stub instead of
+the rendered results. Something has to emulate enough of a browser to clear the
+bot check and retrieve the server-rendered route HTML, while staying cheap
+enough to run for a single personal commute board.
+
+## Decision
+Run a hand-rolled cookie-flow scraper as an AWS Lambda function
+(Node.js 22, ESM) in `src/index.mjs`. The handler performs the multi-hop bot
+handshake (six hops: `nori` -> jid page -> `set_uuid.cgi` -> `verify_uuid.cgi`
+-> redirect -> transit HTML) in `performBotHandshake()`, collecting the
+`jrd_uuid`/`jrd_cuid` cookies the bot check hands out, then parses the route
+HTML directly. Two guards harden the untrusted-input surface: `isAllowedUrl()`
+is an SSRF guard that rejects non-https schemes and off-host joins before any
+follow-up request, and `escapeRegExp()` is a ReDoS guard applied to labels fed
+into the HTML field-extraction regexes.
+
+Rejected alternatives:
+- **A headless browser (Puppeteer/Playwright on Lambda)** — clears the bot
+  check with far less reverse-engineering, but the Chromium layer inflates cold
+  starts and memory cost well beyond what a single commute board justifies.
+- **A paid/third-party transit API** — removes the scraping burden entirely,
+  but no provider exposes Jorudan-equivalent route data for this commute, and
+  the recurring fee defeats the cheapest-possible-board goal.
+
+## Consequences
+- Positive: the function stays within Lambda's free/low-cost envelope, has no
+  browser runtime to patch, and keeps the entire scraping contract in one
+  readable ESM module.
+- Negative (tight coupling to Jorudan's server-rendered output): any change on
+  Jorudan's side silently breaks parsing. The bot check, the
+  `set_uuid.cgi`/`verify_uuid.cgi` handshake, the `<hr size="1" color="black">`
+  result delimiter, or the `発着時間：` route lookahead can each shift without
+  notice and return wrong or empty data with no upstream signal, so recurrence
+  of breakage is expected rather than exceptional.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -1,0 +1,9 @@
+# ADR Index
+
+Lifecycle: Proposed → Accepted (on PR merge) → {Deprecated | Superseded | Rejected}
+
+Do not hand-edit rows; this table is regenerated on each run from the `docs/adr/*.md` file set.
+
+| ID | Title | Status | applyTo | File |
+| --- | --- | --- | --- | --- |
+| 0001 | Jorudan cookie-flow scraper on AWS Lambda | Accepted | src/index.mjs | 0001-jorudan-cookie-flow-scraper.md |


### PR DESCRIPTION
## Summary
Stands up the ADR home so the `x-recording-adr` skill can engage. Before this, the repo had no `docs/adr/` directory, so the skill exited `no-decision` on every run. Adds the MADR-Minimal template, a real seed ADR for the foundational scraper decision, and the index. (The `CLAUDE.md` `adr-dir:` marker is wired separately in #64.)

## Changes
- Add `docs/adr/0000-template.md` — verbatim MADR-Minimal scaffold (frontmatter `status: Proposed` + `applyTo`, the five MADR headings, and a note that `applyTo` is a local extension).
- Add `docs/adr/0001-jorudan-cookie-flow-scraper.md` — seed ADR (`status: Accepted`, `applyTo: src/index.mjs`) recording the hand-rolled Lambda cookie-flow scraper decision, the rejected headless-browser and paid-API alternatives, and the negative tight-coupling consequence. Includes the in-file note that `status: Accepted` is a deliberate hand-seed deviating from the skill's Proposed-only rule.
- Add `docs/adr/INDEX.md` — `| ID | Title | Status | applyTo | File |` table with lifecycle legend, a do-not-hand-edit note, and one data row for 0001.

## Verification
- `npm run lint` — PASS (eslint, no errors; doc-only change).
- `npm run test:unit` — PASS (61/61).
- x-code-reviewer — zero Critical, zero Warning; all seed-ADR code claims verified against `src/index.mjs`.
- Completion grader — ALL acceptance criteria MET:
  - AC1 (three files exist) — MET (`test -f ...` exit 0).
  - AC2 (`status: Accepted` + `applyTo: src/index.mjs` frontmatter) — MET.
  - AC3 (names a rejected option + a negative consequence) — MET (headless browser / paid API rejected; tight-coupling negative).
  - AC4 (no real AWS identifiers under docs/adr/) — MET (grep no matches).
  - AC5 (INDEX header row + exactly one data row) — MET.

Closes #62