### PR TITLE
docs(claude): wire ADR/spec adoption markers and update layout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ CloudFront + S3 (Frontend) → API Gateway → Lambda → Jorudan
 - **API Gateway routes**: `GET /api/transit`, `GET /api/status`
 - **Region**: `ap-northeast-1`
 
-For the AWS topology diagram, the Jorudan 6-hop `jrd_uuid` cookie handshake, HTML parsing rules, ReDoS/SSRF guards, API path normalization, and the full response schema, see [`docs/architecture.md`](./docs/architecture.md). The diagram source lives at [`docs/diagrams/lambda-function-transit-aws-architecture.drawio`](./docs/diagrams/lambda-function-transit-aws-architecture.drawio).
+For the system overview and AWS topology diagram, start at the [`docs/architecture.md`](./docs/architecture.md) index. The detail specs — the Jorudan 6-hop `jrd_uuid` cookie handshake, HTML parsing rules, ReDoS/SSRF guards, API path normalization, and the full response schema — now live in the per-subsystem docs under `docs/architecture/`. The diagram source lives at [`docs/diagrams/lambda-function-transit-aws-architecture.drawio`](./docs/diagrams/lambda-function-transit-aws-architecture.drawio).
 
 ### Repository Layout
 
@@ -41,7 +41,9 @@ For the AWS topology diagram, the Jorudan 6-hop `jrd_uuid` cookie handshake, HTM
 | Frontend | `frontend/Dockerfile` | Frontend container image |
 | Frontend tests | `frontend/tests/` | Vitest unit tests |
 | Frontend tests | `frontend/tests/e2e/` | Playwright E2E tests |
-| Docs | `docs/architecture.md` | Architecture details, cookie flow, parsing, response schema |
+| Docs | `docs/architecture.md` | Architecture overview/index |
+| Docs | `docs/architecture/` | Per-subsystem detail specs (cookie flow, parsing, API contract, observability, deploy/IAM) |
+| Docs | `docs/adr/` | Architecture Decision Records + `INDEX.md` |
 | Docs | `docs/diagrams/` | AWS architecture diagram (`.drawio` + rendered `.png`) |
 
 ### Frontend Sub-Package Convention
@@ -61,6 +63,16 @@ The `frontend/` directory is a self-contained Vite + React workspace with its ow
 |----------|-------------|
 | `ci.yml` | Test backend/frontend, lint, security check, Docker build |
 | `deploy-production.yml` | Manual production deploy with frontend S3 sync |
+
+## Decision & Spec Docs
+
+This repo runs ADR-driven and spec-driven documentation. The adoption markers below opt the `record ADR` and `sync specs` skills in by naming their targets — keep them as bare, unfenced top-level lines, because a code fence or HTML comment defeats the skills' line matching:
+
+adr-dir: docs/adr
+
+spec-doc: docs/architecture.md
+
+What goes where: [`docs/adr/`](./docs/adr/INDEX.md) records *why* a decision was made (immutable; a PR merge promotes Proposed -> Accepted, via `record ADR`); [`docs/architecture.md`](./docs/architecture.md) plus `docs/architecture/*.md` describe *what the system does now* (tracks code, synced via `sync specs`). ADRs never edit specs and specs never edit ADRs.
 
 ## HOW — Development Workflow
 


### PR DESCRIPTION
## Summary
Final child of the docs-bootstrap epic (#65). Wires the opt-in markers into root `CLAUDE.md` so `record ADR` (x-recording-adr) and `sync specs` (x-syncing-specs) discover their targets, documents the what-goes-where workflow, fixes the inbound references broken by the spec split (#63), and confirms the end-to-end bootstrap verification passes.

## Changes
- Add a `## Decision & Spec Docs` section with bare, unfenced top-level markers `adr-dir: docs/adr` and `spec-doc: docs/architecture.md`, plus the what-goes-where guide and links to `docs/adr/INDEX.md` and `docs/architecture.md`.
- Reword the architecture prose to start at the `docs/architecture.md` index and note the detail specs now live under `docs/architecture/`.
- Update the Repository Layout table: `docs/architecture.md` row now reads "Architecture overview/index"; add rows for `docs/architecture/` (detail specs) and `docs/adr/` (ADRs + INDEX).

## Verification
- `npm run lint` — PASS (eslint, no errors).
- `npm run test:unit` — PASS (61/61).
- x-code-reviewer — CLEAN, zero Critical/Warning (markers bare/unfenced, layout rows correct, no stale references, links resolve, no identifier leak, minimal additions).
- Completion grader — ALL acceptance criteria MET:
  - AC1 (`^adr-dir: docs/adr$` present, unfenced) — MET (line 71).
  - AC2 (`^spec-doc:` present, unfenced) — MET (line 73).
  - AC3 (layout rows for docs/adr/ + docs/architecture/, overview/index description) — MET.
  - AC4 (identifier sweep across docs + CLAUDE.md clean) — MET (grep no matches).
  - AC5 (every relative link resolves) — MET (19/19).
  - AC6 (docs/adr + docs/architecture exist; exactly three code-derived docs carry spec-synced-through) — MET.

Closes #64