### PR TITLE
chore(ci): add actionlint gate and fix shellcheck findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,9 @@ jobs:
       - name: Smoke test
         run: |
           docker run -d -p 8000:8000 --name dev-test transit-dev
-          for i in {1..30}; do
-            curl -sf http://localhost:8000/status && break || sleep 1
+          for _ in {1..30}; do
+            if curl -sf http://localhost:8000/status; then break; fi
+            sleep 1
           done
           curl -f http://localhost:8000/status || exit 1
           docker stop dev-test
@@ -81,3 +82,12 @@ jobs:
         with:
           use-installer: true
       - run: sam validate --lint
+
+  validate-workflows:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: actionlint
+        # Third-party linter pinned to an immutable image tag (smaller surface than
+        # adding a third-party Action). Bump deliberately; new versions add new rules.
+        run: docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:1.7.1 -color

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -188,6 +188,9 @@ jobs:
           # CFN reports Target.Name = 'DistributionConfig' at the top level, so a per-property
           # WebACLId filter always returns []. The Modify presence + the secret-vs-live check
           # above are the real gates.
+          # The backticks in the --query value are literal JMESPath syntax (a raw-string
+          # comparison), not a shell command substitution, so SC2016 is a false positive here.
+          # shellcheck disable=SC2016
           CF_CHANGE=$(aws cloudformation describe-change-set \
             --change-set-name "$CHANGESET_ARN" \
             --query 'Changes[?ResourceChange.LogicalResourceId==`CloudFrontDistribution`]' \
@@ -215,10 +218,12 @@ jobs:
           DISTRIBUTION_ID=$(aws cloudformation describe-stacks --stack-name transitmikanmarusan --query "Stacks[0].Outputs[?OutputKey=='CloudFrontDistributionId'].OutputValue" --output text)
           FRONTEND_URL=$(aws cloudformation describe-stacks --stack-name transitmikanmarusan --query "Stacks[0].Outputs[?OutputKey=='FrontendUrl'].OutputValue" --output text)
           API_ENDPOINT=$(aws cloudformation describe-stacks --stack-name transitmikanmarusan --query "Stacks[0].Outputs[?OutputKey=='ApiEndpoint'].OutputValue" --output text)
-          echo "bucket_name=$BUCKET_NAME" >> $GITHUB_OUTPUT
-          echo "distribution_id=$DISTRIBUTION_ID" >> $GITHUB_OUTPUT
-          echo "frontend_url=$FRONTEND_URL" >> $GITHUB_OUTPUT
-          echo "api_endpoint=$API_ENDPOINT" >> $GITHUB_OUTPUT
+          {
+            echo "bucket_name=$BUCKET_NAME"
+            echo "distribution_id=$DISTRIBUTION_ID"
+            echo "frontend_url=$FRONTEND_URL"
+            echo "api_endpoint=$API_ENDPOINT"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Sync frontend to S3
         if: ${{ github.event.inputs.dry-run != 'true' }}


### PR DESCRIPTION
## Summary

Adds a durable `actionlint` CI gate that lints every `.github/workflows/*.yml` on each push/PR, replacing the PR-scoped assistant-side check used for PR #55. Resolves the pre-existing shellcheck findings so the new gate is green.

## Changes

- **`ci.yml`**: new `validate-workflows` job runs `rhysd/actionlint:1.7.1` (pinned Docker image — smaller surface than adding a third-party Action) over the workflow dir.
- **`ci.yml`**: fixed the `docker-build` smoke-test loop the full-repo scan also flagged — SC2034 (unused `i` -> `_`) and SC2015 (`&& break || sleep` -> explicit `if/then`). These were not enumerated in the issue (which only ran actionlint against `deploy-production.yml`), but the gate scans the whole dir, so they had to be fixed for the job to pass.
- **`deploy-production.yml`**: `Get Stack Outputs` — grouped the four `>> $GITHUB_OUTPUT` echoes into `{ ... } >> "$GITHUB_OUTPUT"`, fixing SC2129 and three SC2086.
- **`deploy-production.yml`**: scoped the one genuine SC2016 (literal JMESPath backticks in an `aws --query`, a false positive) with an inline `# shellcheck disable=SC2016` plus rationale. Note: the issue attributed SC2016 to the `grep` line, but the actual trigger is the JMESPath backticks on the `CF_CHANGE` query; the grep's single-quoted regex contains no expansion chars and is not flagged.

## Verification

- `npm run lint` — pass (eslint clean).
- `npm test` — pass (63/63).
- `docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:1.7.1 -no-color` — exit 0 (clean) after fixes; exit 1 before.
- Malformed-YAML check: corrupting a workflow file makes actionlint exit non-zero; restored to clean. Confirmed independently by the completion grader on an isolated scratch copy.
- x-code-reviewer: zero Critical, zero Warning (two optional suggestions: digest-pin the image, add a per-job `permissions: contents: read`).

Acceptance criteria:
- New `validate-workflows` job present and passes (gate exit 0) — **MET**
- Intentional malformed workflow fails the gate (exit non-zero) — **MET**
- Pre-existing `deploy-production.yml` findings resolved (SC2129/SC2086 fixed structurally; SC2016 scoped via inline disable with rationale) — **MET**

Closes #56