### PR TITLE
docs(adr): promote 0000/0002/0003 status to Accepted

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,3 +142,4 @@ The Web ACL itself is **not** managed by this stack (it was created by the Cloud
 ## Lessons
 
 - When authoring an ADR from a planning doc, verify every factual claim against the current code/spec and state present facts as present, proposed changes as proposed. Do not inherit the plan's forward-looking descriptors (e.g. a token value or font stack the plan intends to add) as if they already exist, and do not cite debt/sections that are not actually recorded in the referenced file.
+- When changing an ADR's `status` in `docs/adr/*.md`, also reconcile the matching `Status` cell in `docs/adr/INDEX.md` in the same PR. A manual edit does not trigger the index regeneration, so leaving it stale ships an index that contradicts the source files.

--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,5 +1,5 @@
 ---
-status: Proposed
+status: Accepted
 applyTo: <repo-relative glob>
 ---
 
@@ -8,7 +8,7 @@ applyTo: <repo-relative glob>
 # NNNN. <Title>
 
 ## Status
-Proposed
+Accepted
 
 ## Context
 <the forces and the problem to solve>

--- a/docs/adr/0002-adopt-vite-8-rolldown-frontend-build.md
+++ b/docs/adr/0002-adopt-vite-8-rolldown-frontend-build.md
@@ -1,5 +1,5 @@
 ---
-status: Proposed
+status: Accepted
 applyTo: frontend/**
 ---
 
@@ -8,7 +8,7 @@ applyTo: frontend/**
 # 0002. Adopt Vite 8 (Rolldown/Oxc) for the frontend build
 
 ## Status
-Proposed
+Accepted
 
 ## Context
 Issue #61 asked to upgrade the frontend `vite` 6 → 8 to clear an `esbuild`

--- a/docs/adr/0003-design-md-token-source-of-truth.md
+++ b/docs/adr/0003-design-md-token-source-of-truth.md
@@ -1,5 +1,5 @@
 ---
-status: Proposed
+status: Accepted
 applyTo: frontend/**
 ---
 
@@ -8,7 +8,7 @@ applyTo: frontend/**
 # 0003. DESIGN.md frontmatter as the design-token source of truth
 
 ## Status
-Proposed
+Accepted
 
 ## Context
 DESIGN.md D2 (recorded as a design memo in `frontend/DESIGN.md`, not a formal

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -7,5 +7,5 @@ Do not hand-edit rows; this table is regenerated on each run from the `docs/adr/
 | ID | Title | Status | applyTo | File |
 | --- | --- | --- | --- | --- |
 | 0001 | Jorudan cookie-flow scraper on AWS Lambda | Accepted | src/index.mjs | 0001-jorudan-cookie-flow-scraper.md |
-| 0002 | Adopt Vite 8 (Rolldown/Oxc) for the frontend build | Proposed | frontend/** | 0002-adopt-vite-8-rolldown-frontend-build.md |
-| 0003 | DESIGN.md frontmatter as the design-token source of truth | Proposed | frontend/** | 0003-design-md-token-source-of-truth.md |
+| 0002 | Adopt Vite 8 (Rolldown/Oxc) for the frontend build | Accepted | frontend/** | 0002-adopt-vite-8-rolldown-frontend-build.md |
+| 0003 | DESIGN.md frontmatter as the design-token source of truth | Accepted | frontend/** | 0003-design-md-token-source-of-truth.md |


### PR DESCRIPTION
## Summary
Promotes the three Proposed ADR files (0000-template, 0002, 0003) to status Accepted in both places status is recorded — the YAML frontmatter `status:` field and the `## Status` body line. The decisions behind 0002 (Vite 8, shipped in package.json) and 0003 (merged via PR #83) are already live on main, so promoting them reconciles status with reality.

## Changes
- `docs/adr/0000-template.md`: `status:` and `## Status` -> Accepted
- `docs/adr/0002-adopt-vite-8-rolldown-frontend-build.md`: `status:` and `## Status` -> Accepted
- `docs/adr/0003-design-md-token-source-of-truth.md`: `status:` and `## Status` -> Accepted
- `docs/adr/INDEX.md`: reconcile rows 0002/0003 Status cells to Accepted so the index matches the ADR files (index has no 0000 template row)
- `CLAUDE.md`: add a Lessons entry to reconcile INDEX.md when changing an ADR status
- Historical prose in 0003 Context ("0001 Accepted, 0002 Proposed") left unchanged — it describes state at authoring time, not a live status field

## Verification
Commands run:
- `npm run lint` -> pass (exit 0)
- `npm run test:unit` -> 61 tests pass, 0 fail
- x-code-reviewer -> 0 Critical, 0 Warning (INDEX.md sync warning from round 1 resolved in round 2)

Acceptance criteria:
- [x] `grep -rl '^status: Proposed' docs/adr/` -> no output (MET)
- [x] `grep -A1 '^## Status' docs/adr/*.md | grep Proposed` -> no output (MET)

Closes #84