### PR TITLE
fix(frontend): invert selected origin tab for outdoor legibility

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,5 @@
 # lambda-function-transit - Architecture Spec
-<!-- spec-synced-through: c900150 -->
+<!-- spec-synced-through: 65ee0aa -->
 
 ## 1. Overview
 
@@ -129,7 +129,7 @@ The frontmatter of [`frontend/DESIGN.md`](../frontend/DESIGN.md) is the source o
 
 `frontend/src/index.css` `@import`s the generated file and then declares the hand-authored residue in a single `:root` block:
 
-- **Alias layer** — maps generated names onto the names the existing `*.module.css` call sites use: `--bg-*`, `--border-*`, `--text-primary/secondary/tertiary`, `--accent-*` (from `--color-*`), `--font-size-*` (from `--text-<level>`, which would otherwise collide with the `--text-*` color family), and `--space-*` (from `--spacing-*`). `--radius-sm/md/lg` need no alias — the export already emits those exact names.
+- **Alias layer** — maps generated names onto the names the existing `*.module.css` call sites use: `--bg-*` (including `--bg-inverted`, the selected-tab chip ground), `--border-*`, `--text-primary/secondary/tertiary/inverted`, `--accent-*` (from `--color-*`), `--font-size-*` (from `--text-<level>`, which would otherwise collide with the `--text-*` color family), and `--space-*` (from `--spacing-*`). `--radius-sm/md/lg` need no alias — the export already emits those exact names.
 - **Residue proper** — the tokens `@google/design.md` cannot model, which are their own source of truth: the multi-family font stacks `--font-sans` (Latin → CJK → generic, all OS-bundled faces; no webfont is loaded) / `--font-mono`, and the transition `--transition-fast`.
 
 Translucent colors *are* export-modelable: the exporter passes 8-digit hex (`#rrggbbaa`) through and normalizes `rgba()` into it, so the error-banner tints (`--accent-red-tint` / `--accent-red-tint-border`) live in the frontmatter like any other color. The `design.md` contrast lint is not alpha-aware, though, so those tints are modeled as `textColor`-less surface components and their real (composited) contrast is pinned in Vitest instead.
@@ -430,6 +430,7 @@ If any step fails with an `AccessDenied`, read the denied action/resource from t
 - **call-site hygiene**: `*.module.css` sizes text only from the `--font-size-*` scale (never a raw px), writes no raw `rgba()`/hex color, and no stylesheet loads a webfont (`@font-face` / CDN URL);
 - **`--font-sans` carries a CJK face**, ordered Latin → CJK → generic;
 - **WCAG AA contrast**: `--text-tertiary` clears 4.5:1 on `bg-primary`/`secondary`/`tertiary`, the error banner's text clears 4.5:1 against its *composited* translucent tint, and the empty-state text clears 4.5:1 on its elevated card. A negative control asserts the pre-ADR value (`#737373`) still fails, so the ratio maths cannot go vacuously green;
+- **outdoor-legibility inverted chip (ADR 0004)**: reads the actual `.tabActive` declarations out of `App.module.css` and resolves them through the alias/generated pipeline — not just the token value, so repointing the chip back at `--bg-secondary` fails the test rather than passing vacuously — then asserts the selected chip fill clears 3:1 against the unselected-tab substrate (WCAG 1.4.11), its label clears 4.5:1 on the chip fill (WCAG 1.4.3), and the `--accent-blue` focus ring clears 3:1 against both the near-white chip and `--bg-primary`. A teeth test pins the old `#111111` fill at 1.05:1 (< 3:1) so the 3:1 checks cannot go vacuously green;
 - **`design.md lint` reports zero errors and zero warnings** — this runs the pinned local bin from the test suite, so the frontmatter's lint cleanliness is enforced by `npm test` (which CI runs) rather than only by hand.
 
 ### Frontend Accessibility & Responsive Conventions
@@ -450,7 +451,8 @@ Rules that hold across the frontend's stylesheets, not just one component:
 - the 44×44 hit areas, measured by probing `document.elementFromPoint` outwards from each control's centre (`boundingBox()` cannot see the `::after`), plus that a crowded tab strip scrolls rather than clipping its labels;
 - `animation-name: none` for the spinner and the pulse dot under an emulated `reducedMotion: 'reduce'`, and that both animate when no preference is set;
 - the computed CJK values (`line-break`, line-height ratio, `letter-spacing`, `word-break`) and that `break-word` reaches `.rawRoute` alone;
-- the computed accent/surface colors of the arrival time, the error banner, and the empty card.
+- the computed accent/surface colors of the arrival time, the error banner, and the empty card;
+- that the selected origin tab stays a near-white inverted chip (`rgb(250, 250, 250)`, `--bg-inverted`) even while hovered — reading the settled colour after the 100ms transition — which guards the `.tab:hover:not(.tabActive)` specificity fix (ADR 0004).
 
 CI (`.github/workflows/ci.yml`) runs `npm test` (Vitest) for both packages but **does not run Playwright** — the E2E suite is a local gate.
 

--- a/frontend/DESIGN.md
+++ b/frontend/DESIGN.md
@@ -16,6 +16,8 @@ colors:
   text-primary: "#fafafa"
   text-secondary: "#a1a1a1"
   text-tertiary: "#8a8a8a"
+  bg-inverted: "#fafafa"
+  text-inverted: "#0a0a0a"
   accent-blue: "#3b82f6"
   accent-blue-hover: "#2563eb"
   accent-green: "#22c55e"
@@ -81,10 +83,13 @@ components:
     rounded: "{rounded.md}"
     padding: "{spacing.1}"
   tab-active:
-    backgroundColor: "{colors.bg-secondary}"
-    textColor: "{colors.text-primary}"
+    backgroundColor: "{colors.bg-inverted}"
+    textColor: "{colors.text-inverted}"
     typography: "{typography.base}"
     rounded: "{rounded.md}"
+  tab-border:
+    backgroundColor: "{colors.border-primary}"
+    height: 1px
   refresh-button:
     backgroundColor: "{colors.bg-secondary}"
     textColor: "{colors.text-primary}"
@@ -233,6 +238,8 @@ components:
 | `--text-primary` | `colors.text-primary` | `#fafafa` | 本文・主要テキスト |
 | `--text-secondary` | `colors.text-secondary` | `#a1a1a1` | 補助テキスト（タブ非選択・ステータスラベル・ローディング文言・空状態文言） |
 | `--text-tertiary` | `colors.text-tertiary` | `#8a8a8a` | 装飾・最小ウェイト（矢印・フッター・タイムスタンプ・路線名）。**WCAG AA 達成値**（ADR 0003 D-E） |
+| `--bg-inverted` | `colors.bg-inverted` | `#fafafa` | 選択中タブ（反転チップ）の地。屋外グレア下で選択状態が唯一残る近白面（ADR 0004。地に `--text-*` を塗らないための専用ロール） |
+| `--text-inverted` | `colors.text-inverted` | `#0a0a0a` | 選択中タブ（反転チップ）のラベル。近白地に対し 18.97:1（ADR 0004） |
 | `--accent-blue` | `colors.accent-blue` | `#3b82f6` | 到着時刻・ロゴ・タイムライン dot・active ボーダー・focus リング |
 | `--accent-blue-hover` | `colors.accent-blue-hover` | `#2563eb` | refresh ボタンの**押下（`:active`）地／罫**（TD#4 で役割確定） |
 | `--accent-green` | `colors.accent-green` | `#22c55e` | status OK アイコン（Connected） |
@@ -428,7 +435,12 @@ components:
   `--radius-md`、色 `--text-secondary`、`--font-size-base`/`500`、`line-height: 1.6`・`word-break: normal`・
   `line-break: strict`（CJK 体裁）、`white-space: nowrap`、`transition: all --transition-fast`。
   選択状態は **`aria-pressed`**（`origin === activeOrigin`）で支援技術に出す。
-- `.tab:hover`: 地 `--bg-secondary`、色 `--text-primary`。`.tabActive`: 地 `--bg-secondary`、ボーダー `--border-secondary`、色 `--text-primary`。
+- `.tab:hover:not(.tabActive)`: 地 `--bg-secondary`、色 `--text-primary`。**`:not(.tabActive)` で非選択タブに限定する**のは
+  必須: 無印 `.tab:hover`(0,2,0) は `.tabActive`(0,1,0) を出し抜くため、反転チップが白になった瞬間、選択中タブをホバー
+  すると地が暗く塗り戻る（iOS ではタップ後に `:hover` が残る）。`.tabActive`: **反転チップ**。地/ボーダー `--bg-inverted`
+  （近白）、ラベル `--text-inverted`（近黒）。選択 vs 非選択のコントラストを 1.05:1 → **18.97:1** に上げ、屋外の 20% グレア
+  veil 下でも選択状態が残る唯一の要素（ADR 0004）。非選択タブの 1px ボーダーは `--border-primary`（frontmatter
+  `components.tab-border`）。
 - `.route`: `activeOrigin` + `ArrowRight`（16, 色 `--text-tertiary`）+ `つつじヶ丘`。`.station` は `--font-size-md`/`500`/
   `--text-primary`、`line-height: 1.6`・`word-break: normal`・`line-break: strict`。
 - `.refreshButton`: **視覚 `32px × 32px`**、地 `--bg-secondary`、ボーダー `--border-primary`、`--radius-md`、

--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -96,15 +96,21 @@
   white-space: nowrap;
 }
 
-.tab:hover {
+/* Scoped :not(.tabActive): `.tab:hover` is (0,2,0) and `.tabActive` is (0,1,0), so an unscoped
+   hover rule OUT-SPECIFIES the active rule. Once the chip turns white that matters - on iOS
+   :hover sticks after a tap, so hovering the selected tab would repaint the chip you just
+   selected back to the dark unselected fill. */
+.tab:hover:not(.tabActive) {
   background-color: var(--bg-secondary);
   color: var(--text-primary);
 }
 
+/* Inverted chip: near-white fill, near-black label (ADR 0004). Takes selected-vs-unselected
+   separation from 1.05:1 to 18.97:1 - the only element that survives a 20% outdoor veil. */
 .tabActive {
-  background-color: var(--bg-secondary);
-  border-color: var(--border-secondary);
-  color: var(--text-primary);
+  background-color: var(--bg-inverted);
+  border-color: var(--bg-inverted);
+  color: var(--text-inverted);
 }
 
 .route {

--- a/frontend/src/design-tokens.css
+++ b/frontend/src/design-tokens.css
@@ -12,6 +12,8 @@
   --color-text-primary: #fafafa;
   --color-text-secondary: #a1a1a1;
   --color-text-tertiary: #8a8a8a;
+  --color-bg-inverted: #fafafa;
+  --color-text-inverted: #0a0a0a;
   --color-accent-blue: #3b82f6;
   --color-accent-blue-hover: #2563eb;
   --color-accent-green: #22c55e;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -31,6 +31,11 @@
   --text-secondary: var(--color-text-secondary);
   --text-tertiary: var(--color-text-tertiary);
 
+  /* Inverted chip (selected origin tab): near-white fill, near-black label - the one
+     separation that survives an outdoor ambient veil (ADR 0004). */
+  --bg-inverted: var(--color-bg-inverted);
+  --text-inverted: var(--color-text-inverted);
+
   --accent-blue: var(--color-accent-blue);
   --accent-blue-hover: var(--color-accent-blue-hover);
   --accent-green: var(--color-accent-green);

--- a/frontend/tests/design-tokens.test.ts
+++ b/frontend/tests/design-tokens.test.ts
@@ -210,6 +210,52 @@ function token(name: string): string {
   return value
 }
 
+/**
+ * The App module CSS, read as the source of truth for what a rule *actually paints* - a
+ * token-value-only contrast contract passes vacuously (it stays green even if someone repoints
+ * .tabActive back at --bg-secondary, the exact regression issue #95 exists to prevent). These
+ * helpers read the declaration off the rule and throw when the rule or property is absent, so
+ * deleting the rule fails the test rather than skipping it.
+ */
+const appModuleCss = stripComments(readFileSync(join(srcDir, 'App.module.css'), 'utf-8'))
+
+/** The body of a single-class rule `.name { ... }`. Throws when there is no such rule. */
+function ruleBody(css: string, selector: string): string {
+  const match = new RegExp(`\\.${selector}\\s*\\{([^}]*)\\}`).exec(css)
+  if (!match) throw new Error(`no .${selector} rule in App.module.css`)
+  return match[1]
+}
+
+/** A single property's value inside a rule body. Throws when the property is not declared. */
+function declaredValue(body: string, property: string, selector: string): string {
+  const match = new RegExp(`(?:^|;|\\{)\\s*${property}\\s*:\\s*([^;}]+)`).exec(body)
+  if (!match) throw new Error(`no ${property} in .${selector} rule`)
+  return match[1].trim()
+}
+
+/** Follows a `var(--x)` chain through the index.css alias layer down to the generated literal. */
+const aliasValues = new Map(rootDeclarations(indexCss))
+function resolveColor(value: string): string {
+  let current = value.trim()
+  const seen = new Set<string>()
+  while (current.startsWith('var(')) {
+    const ref = /^var\(\s*(--[\w-]+)\s*\)$/.exec(current)
+    if (!ref) throw new Error(`cannot resolve non-var() reference: ${current}`)
+    const name = ref[1]
+    if (seen.has(name)) throw new Error(`cycle while resolving ${name}`)
+    seen.add(name)
+    const next = aliasValues.get(name) ?? generatedValues.get(name)
+    if (next === undefined) throw new Error(`token not defined anywhere: ${name}`)
+    current = next.trim()
+  }
+  return current
+}
+
+/** The hex a rule's colour property actually paints, resolved through the token pipeline. */
+function paintedColor(selector: string, property: string): string {
+  return resolveColor(declaredValue(ruleBody(appModuleCss, selector), property, selector))
+}
+
 describe('design token pipeline', () => {
   it('has CSS sources to check', () => {
     expect(cssFiles).toContain(generatedPath)
@@ -486,6 +532,44 @@ describe('WCAG AA contrast (ADR 0003 D-E)', () => {
     // the AA tests above would be vacuously green.
     const ratio = contrastRatio(parseHex('#737373'), parseHex(token('--color-bg-primary')))
     expect(ratio).toBeLessThan(4.5)
+  })
+})
+
+describe('outdoor-legibility inverted chip (issue #95, ADR 0004)', () => {
+  // These read the CSS declaration off .tabActive, not just the token value: a token-only
+  // contract stays green even if .tabActive is repointed back at --bg-secondary, which is the
+  // exact 1.05:1 regression this exists to prevent. paintedColor() throws when the rule or the
+  // property it guards is missing, so deleting the rule fails the test rather than skipping it.
+  const chipFill = paintedColor('tabActive', 'background-color')
+  const chipLabel = paintedColor('tabActive', 'color')
+  const tabFill = declaredValue(ruleBody(appModuleCss, 'tab'), 'background-color', 'tab')
+  // An unselected tab paints `transparent`, so its effective substrate is the page ground.
+  const tabSubstrate = tabFill === 'transparent' ? token('--color-bg-primary') : resolveColor(tabFill)
+
+  it('paints the selected chip vs the unselected tab substrate at >= 3:1 (WCAG 1.4.11)', () => {
+    const ratio = contrastRatio(parseHex(chipFill), parseHex(tabSubstrate))
+    expect(ratio).toBeGreaterThanOrEqual(3)
+  })
+
+  it('paints the chip label on the chip fill at >= 4.5:1 (WCAG 1.4.3)', () => {
+    const ratio = contrastRatio(parseHex(chipLabel), parseHex(chipFill))
+    expect(ratio).toBeGreaterThanOrEqual(4.5)
+  })
+
+  it.each([
+    ['the chip fill', () => chipFill],
+    ['--bg-primary', () => token('--color-bg-primary')],
+  ])('keeps the focus ring (--accent-blue) at >= 3:1 against %s', (_label, background) => {
+    // The white chip is the one surface that could swallow the blue focus ring; pin both grounds.
+    const ratio = contrastRatio(parseHex(token('--color-accent-blue')), parseHex(background()))
+    expect(ratio).toBeGreaterThanOrEqual(3)
+  })
+
+  it('still fails the old .tabActive fill (#111111 = 1.05:1), proving the 3:1 check has teeth', () => {
+    // Guards the guard: the old fill sat at 1.05:1 on the page ground. If this ever reaches 3:1
+    // the ratio maths has broken and the contract above would be vacuously green.
+    const ratio = contrastRatio(parseHex('#111111'), parseHex(token('--color-bg-primary')))
+    expect(ratio).toBeLessThan(3)
   })
 })
 

--- a/frontend/tests/e2e/transit.spec.ts
+++ b/frontend/tests/e2e/transit.spec.ts
@@ -393,6 +393,28 @@ test.describe('CJK typography', () => {
   })
 })
 
+test.describe('Inverted selected chip (issue #95, ADR 0004)', () => {
+  test('keeps the selected tab a near-white chip even while hovered', async ({ page }) => {
+    // The specificity trap: `.tab:hover` (0,2,0) out-specifies `.tabActive` (0,1,0), so an
+    // unscoped hover rule would repaint the selected chip dark - and on iOS :hover sticks after
+    // a tap, so a tap on the selected tab would visibly un-invert it. `:not(.tabActive)` fixes it.
+    await mockApi(page)
+    await page.goto('/')
+
+    const active = page.getByRole('button', { name: ROPPONGI })
+    await expect(active).toHaveAttribute('aria-pressed', 'true')
+    // The inverted chip fill, --bg-inverted #fafafa.
+    expect(await computed(active, 'background-color')).toBe('rgb(250, 250, 250)')
+
+    await active.hover()
+    // `.tab` carries a 100ms `transition: all`, so wait past it and read the settled colour: an
+    // unscoped `.tab:hover` would animate the chip to the dark --bg-secondary fill, but reading
+    // at t=0 would still catch the near-white start frame and miss the regression.
+    await page.waitForTimeout(300)
+    expect(await computed(active, 'background-color')).toBe('rgb(250, 250, 250)')
+  })
+})
+
 test.describe('Computed token values', () => {
   test('paints arrival time with the blue accent and the error banner with red', async ({
     page,


### PR DESCRIPTION
## Summary

The selected origin tab was invisible outdoors: its `--bg-secondary` (`#111111`) fill sat at 1.05:1 against the page ground and its border at 1.57:1 — separations that only exist in a dark room and vanish under ambient glare. This makes the selected tab an **inverted chip** (near-white fill, near-black label), taking selected-vs-unselected separation from 1.05:1 to 18.97:1 — the only element that survives a ~20% outdoor ambient veil (ADR 0004).

## Changes

- **`frontend/DESIGN.md` frontmatter**: added `colors.bg-inverted` (`#fafafa`) and `colors.text-inverted` (`#0a0a0a`); repointed `tab-active` to those roles; added a `tab-border` component entry (`border-primary`, 1px) recording the unselected tab's border so `border-primary` cannot be orphaned. Swept the Colors table and Components prose.
- **`frontend/src/design-tokens.css`**: regenerated via `npm run export:design` (adds `--color-bg-inverted` / `--color-text-inverted`).
- **`frontend/src/index.css`**: alias layer adds `--bg-inverted` / `--text-inverted` (each a `var(--color-*)`).
- **`frontend/src/App.module.css`**: `.tabActive` now paints the inverted chip through tokens; `.tab:hover` is scoped to `.tab:hover:not(.tabActive)` to fix a specificity trap — `.tab:hover` (0,2,0) out-specified `.tabActive` (0,1,0), so hovering the selected tab (which sticks after a tap on iOS) would have un-inverted the chip.
- **Tests**: three new contrast contracts in `design-tokens.test.ts` that read the actual `.tabActive` CSS declarations (throwing when the rule/property is absent, so a repoint back to `--bg-secondary` fails rather than passing vacuously) plus a teeth test on the old `#111111` value; one e2e hover test in `transit.spec.ts` asserting the chip stays `rgb(250, 250, 250)`.

## Verification

Commands (run under `frontend/`):
- `npm test` — exit 0, **84 passed** (includes the three new contracts a/b/c and the teeth test)
- `npx playwright test transit.spec.ts` — **42 passed** (includes the new hover test)
- `npm run lint:design` — `"errors":0`, `"warnings":0`
- `npm run lint` — exit 0
- `npm run typecheck` — exit 0
- `npm run build` — exit 0

Acceptance criteria (all MET, graded by an independent grader):
- (1) `npm test` exit 0 with contracts (a) chip fill vs unselected substrate `>= 3:1`, (b) label vs fill `>= 4.5:1`, (c) focus ring `--accent-blue` `>= 3:1` vs BOTH chip fill and `--bg-primary` — MET
- (2) contracts read CSS declarations and throw when the rule is absent (`grep` exit 0) — MET
- (3) teeth test on old `#111111` asserted `< 3:1` (`grep` exit 0) — MET
- (4) `lint:design` errors:0 warnings:0 — MET
- (5) `tab-border` in DESIGN.md (`grep` exit 0) — MET
- (6) `:not(.tabActive)` in App.module.css (`grep` exit 0) — MET
- (7) no raw `#fafafa`/`#0a0a0a` hex in App.module.css (`grep` exit 1) — MET
- (8) `lint && typecheck && build` all exit 0 — MET

All three contracts were mutation-tested red (revert `.tabActive` fill to `--bg-secondary` → 3:1 fails; label to `--text-secondary`/2.48:1 → 4.5:1 fails; remove `:not(.tabActive)` → e2e hover reads `rgb(17, 17, 17)` and fails), and the rule-absent case throws `no .tabActive rule`.

Prerequisite ADR 0004 confirmed `Accepted` on `main`.

Code review: x-code-reviewer reported 0 Critical, 0 Warning (2 optional Suggestions).

Closes #95