### PR TITLE
fix(frontend): strengthen the transit card outline for outdoor glare

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,5 @@
 # lambda-function-transit - Architecture Spec
-<!-- spec-synced-through: 65ee0aa -->
+<!-- spec-synced-through: e50f968 -->
 
 ## 1. Overview
 
@@ -431,6 +431,7 @@ If any step fails with an `AccessDenied`, read the denied action/resource from t
 - **`--font-sans` carries a CJK face**, ordered Latin → CJK → generic;
 - **WCAG AA contrast**: `--text-tertiary` clears 4.5:1 on `bg-primary`/`secondary`/`tertiary`, the error banner's text clears 4.5:1 against its *composited* translucent tint, and the empty-state text clears 4.5:1 on its elevated card. A negative control asserts the pre-ADR value (`#737373`) still fails, so the ratio maths cannot go vacuously green;
 - **outdoor-legibility inverted chip (ADR 0004)**: reads the actual `.tabActive` declarations out of `App.module.css` and resolves them through the alias/generated pipeline — not just the token value, so repointing the chip back at `--bg-secondary` fails the test rather than passing vacuously — then asserts the selected chip fill clears 3:1 against the unselected-tab substrate (WCAG 1.4.11), its label clears 4.5:1 on the chip fill (WCAG 1.4.3), and the `--accent-blue` focus ring clears 3:1 against both the near-white chip and `--bg-primary`. A teeth test pins the old `#111111` fill at 1.05:1 (< 3:1) so the 3:1 checks cannot go vacuously green;
+- **outdoor-legibility card outline (issue #96, ADR 0004)**: reads the actual `.card` / `.card:hover` declarations out of `TransitCard.module.css` and resolves them through the token pipeline — not just the token value, so repointing the card back at `--border-primary` fails the test rather than passing vacuously — then asserts the resting card outline (`--border-tertiary`) clears 2:1 against both the page ground and the card's own `--bg-elevated` fill (a **house** threshold matching Material 3's `outlineVariant` parity, explicitly not a WCAG boundary requirement), the hover outline (`--border-elevated`) is strictly brighter than the resting outline (no inverted ramp), and `--accent-blue` clears 4.5:1 on the elevated card fill (pinning the card ground at its AA ceiling). A teeth test pins the old `#262626` and `#333333` outlines below 2:1 against the page so the checks cannot go vacuously green;
 - **`design.md lint` reports zero errors and zero warnings** — this runs the pinned local bin from the test suite, so the frontmatter's lint cleanliness is enforced by `npm test` (which CI runs) rather than only by hand.
 
 ### Frontend Accessibility & Responsive Conventions
@@ -451,7 +452,7 @@ Rules that hold across the frontend's stylesheets, not just one component:
 - the 44×44 hit areas, measured by probing `document.elementFromPoint` outwards from each control's centre (`boundingBox()` cannot see the `::after`), plus that a crowded tab strip scrolls rather than clipping its labels;
 - `animation-name: none` for the spinner and the pulse dot under an emulated `reducedMotion: 'reduce'`, and that both animate when no preference is set;
 - the computed CJK values (`line-break`, line-height ratio, `letter-spacing`, `word-break`) and that `break-word` reaches `.rawRoute` alone;
-- the computed accent/surface colors of the arrival time, the error banner, and the empty card;
+- the computed accent/surface colors of the arrival time, the error banner, and the empty card, plus the card's elevated `--bg-elevated` fill (`rgb(26, 26, 26)`) and `--border-tertiary` outdoor-legibility outline (`rgb(102, 102, 102)`);
 - that the selected origin tab stays a near-white inverted chip (`rgb(250, 250, 250)`, `--bg-inverted`) even while hovered — reading the settled colour after the 100ms transition — which guards the `.tab:hover:not(.tabActive)` specificity fix (ADR 0004).
 
 CI (`.github/workflows/ci.yml`) runs `npm test` (Vitest) for both packages but **does not run Playwright** — the E2E suite is a local gate.

--- a/frontend/DESIGN.md
+++ b/frontend/DESIGN.md
@@ -13,6 +13,8 @@ colors:
   bg-elevated: "#1a1a1a"
   border-primary: "#262626"
   border-secondary: "#333333"
+  border-tertiary: "#666666"
+  border-elevated: "#8a8a8a"
   text-primary: "#fafafa"
   text-secondary: "#a1a1a1"
   text-tertiary: "#8a8a8a"
@@ -65,16 +67,16 @@ spacing:
   12: 48px
 components:
   card:
-    backgroundColor: "{colors.bg-secondary}"
+    backgroundColor: "{colors.bg-elevated}"
     textColor: "{colors.text-primary}"
     typography: "{typography.base}"
     rounded: "{rounded.lg}"
     padding: "{spacing.4}"
   card-border:
-    backgroundColor: "{colors.border-primary}"
+    backgroundColor: "{colors.border-tertiary}"
     height: 1px
   card-border-hover:
-    backgroundColor: "{colors.border-secondary}"
+    backgroundColor: "{colors.border-elevated}"
     height: 1px
   tab:
     backgroundColor: "{colors.bg-primary}"
@@ -104,6 +106,9 @@ components:
     textColor: "{colors.text-secondary}"
     typography: "{typography.xs}"
     rounded: "{rounded.sm}"
+  badge-border:
+    backgroundColor: "{colors.border-tertiary}"
+    height: 1px
   status-indicator:
     backgroundColor: "{colors.bg-secondary}"
     textColor: "{colors.text-secondary}"
@@ -210,7 +215,7 @@ components:
 
 - **ダーク専用**の単一テーマ。`index.html` は `<html lang="ja">`、`<meta name="theme-color" content="#0a0a0a">`、
   `<title>Transit - 六本木一丁目 → つつじヶ丘</title>`。
-- **影を使わない border ベースの奥行き**（詳細は Elevation & Depth）。背景4段とボーダー2段で階層を表現する。
+- **影を使わない border ベースの奥行き**（詳細は Elevation & Depth）。背景4段とボーダー4段で階層を表現する。
 - **4px グリッド**（`--space-*`、Layout）。**最大幅 600px の単一カラム**を中央寄せした、グランス用（一瞥用）ボード。
 - 日本語（駅名・所要時間・`つつじヶ丘`）と Latin 等幅（時刻・ステータスのタイムスタンプ）の**混植**。
 - 出典: `frontend/index.html`、`frontend/src/index.css`、ルート `CLAUDE.md` の "Frontend Design"。
@@ -230,11 +235,13 @@ components:
 | トークン（呼び出し名） | frontmatter | 値 | 役割（実使用） |
 |---|---|---|---|
 | `--bg-primary` | `colors.bg-primary` | `#0a0a0a` | ページ地・ヘッダー地（純黒を避けた最暗段） |
-| `--bg-secondary` | `colors.bg-secondary` | `#111111` | カード地・タブ active 地・refresh ボタン地・StatusIndicator 地 |
-| `--bg-tertiary` | `colors.bg-tertiary` | `#171717` | バッジ地・RouteDetail コンテナ地・refresh hover 地 |
-| `--bg-elevated` | `colors.bg-elevated` | `#1a1a1a` | 最上段の面。**空状態カードの地**（`.empty`。TD#4 で役割確定） |
-| `--border-primary` | `colors.border-primary` | `#262626` | 既定のボーダー（カード・タブ・ボタン・区切り線・空状態カード） |
-| `--border-secondary` | `colors.border-secondary` | `#333333` | hover / active 時の一段明るいボーダー・タイムライン縦線・lineName 左罫 |
+| `--bg-secondary` | `colors.bg-secondary` | `#111111` | タブ hover 地・refresh ボタン地・StatusIndicator 地 |
+| `--bg-tertiary` | `colors.bg-tertiary` | `#171717` | RouteDetail コンテナ地・refresh hover 地 |
+| `--bg-elevated` | `colors.bg-elevated` | `#1a1a1a` | 最上段の面。**カード地**（TransitCard・空状態カード `.empty`）。屋外可読性のためカード地をこの段まで引き上げた（issue #96 / ADR 0004 D-4 が上限。`--accent-blue` 到着時刻が 4.73:1 でぎりぎり AA） |
+| `--border-primary` | `colors.border-primary` | `#262626` | 既定のボーダー（タブ・ボタン・区切り線・空状態カード） |
+| `--border-secondary` | `colors.border-secondary` | `#333333` | refresh ボタン hover / active の一段明るいボーダー・タイムライン縦線・lineName 左罫・スクロールバー thumb |
+| `--border-tertiary` | `colors.border-tertiary` | `#666666` | カードの既定アウトライン・バッジのアウトライン。ページ地に 3.45:1 / カード地に 3.03:1（issue #96 / ADR 0004。2:1 の house 閾値を満たす） |
+| `--border-elevated` | `colors.border-elevated` | `#8a8a8a` | カード hover 時のアウトライン（resting `--border-tertiary` より明るい＝ボーダーランプは単調） |
 | `--text-primary` | `colors.text-primary` | `#fafafa` | 本文・主要テキスト |
 | `--text-secondary` | `colors.text-secondary` | `#a1a1a1` | 補助テキスト（タブ非選択・ステータスラベル・ローディング文言・空状態文言） |
 | `--text-tertiary` | `colors.text-tertiary` | `#8a8a8a` | 装飾・最小ウェイト（矢印・フッター・タイムスタンプ・路線名）。**WCAG AA 達成値**（ADR 0003 D-E） |
@@ -378,8 +385,11 @@ components:
 
 - **影（box-shadow）を一切使わない。** 参照テンプレートの shadow 立体モデルからの**意図的な乖離**。
 - 奥行きは**背景4段**（`--bg-primary` → `--bg-secondary` → `--bg-tertiary` → `--bg-elevated`）と
-  **ボーダー2段**（`--border-primary` → `--border-secondary`）で表現する。
-- hover はボーダーを一段明るく（`--border-primary` → `--border-secondary`）。
+  **ボーダー4段**（`--border-primary` → `--border-secondary` → `--border-tertiary` → `--border-elevated`）で表現する。
+  ボーダーランプは単調に明るくなる（`#262626` → `#333333` → `#666666` → `#8a8a8a`）。カードは屋外グレア下でも
+  縁が残るよう `--border-tertiary`（ページ地に 3.45:1、house 閾値 2:1 を満たす）を既定アウトラインに使う（issue #96 / ADR 0004）。
+- hover はボーダーを一段明るくする（refresh ボタン: `--border-primary` → `--border-secondary`／
+  カード: `--border-tertiary` → `--border-elevated`）。
 - **focus-visible**: `outline: 2px solid var(--accent-blue); outline-offset: 2px`（全要素共通、`index.css` の
   reset/focus 区画）。frontmatter では `components.focus-ring` として記録。
 
@@ -475,12 +485,15 @@ components:
 
 #### TransitCard（`TransitCard.tsx` / `TransitCard.module.css`）
 
-- `.card`: 地 `--bg-secondary`、ボーダー `--border-primary`、`--radius-lg`、`overflow: hidden`、
-  `transition: border-color --transition-fast`。`.card:hover` でボーダー `--border-secondary`。
+- `.card`: 地 `--bg-elevated`、ボーダー `--border-tertiary`、`--radius-lg`、`overflow: hidden`、
+  `transition: border-color --transition-fast`。`.card:hover` でボーダー `--border-elevated`（resting `--border-tertiary` より
+  **明るい**。旧 `--border-secondary` #333333 は今や resting より暗く、残すと hover がカードを暗く沈ませる逆ランプになる。issue #96 / ADR 0004）。
 - `.header`（button）: `gap: --space-4`、padding `--space-4`、`background: none; border: none; font: inherit`、`aria-expanded={expanded}`。
 - `.times`: `.departure`/`.arrival` は `--font-size-xl`/`600`/`--font-mono`/`letter-spacing: -0.02em`。`.arrival` は色 `--accent-blue`。
   区切りの `.arrow`（`→`）は `--text-tertiary`/`--font-size-md`。
-- `.meta`: `.badge` ×2（`Clock` 12/bold + 所要、`ArrowsDownUp` 12/bold + 乗換回数）。バッジは地 `--bg-tertiary`、`--radius-sm`、`--font-size-xs`/`500`、色 `--text-secondary`。
+- `.meta`: `.badge` ×2（`Clock` 12/bold + 所要、`ArrowsDownUp` 12/bold + 乗換回数）。バッジは**アウトライン idiom**
+  （地 `transparent`・`1px solid --border-tertiary`。`components.badge-border`）、`--radius-sm`、`--font-size-xs`/`500`、色 `--text-secondary`。
+  旧 `--bg-tertiary` #171717 塗りは引き上げたカード地 #1a1a1a に対し 1.03:1 でカードより暗く沈むため、未選択 `.tab` と同じアウトライン idiom に寄せた（issue #96）。ラベルはカード地 #1a1a1a で 6.74:1。
 - `.expandIcon`: `CaretUp`（展開時）/ `CaretDown`（折りたたみ時）、16、色 `--text-tertiary`。
 - `.body`: padding `0 --space-4 --space-4`、`RouteDetail` を内包。
 - **先頭カード（`index === 0`）は既定で展開**（`useState(index === 0)`）。

--- a/frontend/src/components/TransitCard.module.css
+++ b/frontend/src/components/TransitCard.module.css
@@ -1,13 +1,13 @@
 .card {
-  background-color: var(--bg-secondary);
-  border: 1px solid var(--border-primary);
+  background-color: var(--bg-elevated);
+  border: 1px solid var(--border-tertiary);
   border-radius: var(--radius-lg);
   overflow: hidden;
   transition: border-color var(--transition-fast);
 }
 
 .card:hover {
-  border-color: var(--border-secondary);
+  border-color: var(--border-elevated);
 }
 
 .header {
@@ -59,7 +59,8 @@
   align-items: center;
   gap: var(--space-1);
   padding: var(--space-1) var(--space-2);
-  background-color: var(--bg-tertiary);
+  background-color: transparent;
+  border: 1px solid var(--border-tertiary);
   border-radius: var(--radius-sm);
   font-size: var(--font-size-xs);
   font-weight: 500;

--- a/frontend/src/design-tokens.css
+++ b/frontend/src/design-tokens.css
@@ -9,6 +9,8 @@
   --color-bg-elevated: #1a1a1a;
   --color-border-primary: #262626;
   --color-border-secondary: #333333;
+  --color-border-tertiary: #666666;
+  --color-border-elevated: #8a8a8a;
   --color-text-primary: #fafafa;
   --color-text-secondary: #a1a1a1;
   --color-text-tertiary: #8a8a8a;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -26,6 +26,8 @@
 
   --border-primary: var(--color-border-primary);
   --border-secondary: var(--color-border-secondary);
+  --border-tertiary: var(--color-border-tertiary);
+  --border-elevated: var(--color-border-elevated);
 
   --text-primary: var(--color-text-primary);
   --text-secondary: var(--color-text-secondary);

--- a/frontend/tests/design-tokens.test.ts
+++ b/frontend/tests/design-tokens.test.ts
@@ -573,6 +573,62 @@ describe('outdoor-legibility inverted chip (issue #95, ADR 0004)', () => {
   })
 })
 
+describe('outdoor-legibility card outline (issue #96, ADR 0004)', () => {
+  // The 2:1 card-border thresholds below are a HOUSE threshold, NOT a WCAG one: WCAG 1.4.11
+  // explicitly does not require a boundary on a container, and no 2:1 value exists anywhere in
+  // WCAG. The provenance is parity with Material 3's outlineVariant (1.99:1 on its dark surface).
+  // Do not relabel these as WCAG (ADR 0004 D-2).
+  //
+  // These read the declaration off TransitCard.module.css, not just the token value: a
+  // token-only contract stays green even if .card is repointed back at --border-primary (the
+  // 1.31:1 regression this exists to prevent). borderColor()/paintedCardColor() throw when the
+  // rule or property is missing, so deleting a rule fails the test rather than skipping it.
+  const cardModuleCss = stripComments(
+    readFileSync(join(srcDir, 'components', 'TransitCard.module.css'), 'utf-8')
+  )
+
+  /** The card fill actually painted by a rule, resolved through the token pipeline. */
+  function paintedCardColor(selector: string, property: string): string {
+    return resolveColor(declaredValue(ruleBody(cardModuleCss, selector), property, selector))
+  }
+
+  /** The border colour of a rule, whether written as `border: 1px solid var(--x)` or `border-color: var(--x)`. */
+  function borderColor(selector: string): string {
+    const body = ruleBody(cardModuleCss, selector)
+    const match = /border(?:-color)?\s*:\s*(?:[^;}]*?\s)?(var\(\s*--[\w-]+\s*\))/.exec(body)
+    if (!match) throw new Error(`no border colour in .${selector} rule`)
+    return resolveColor(match[1])
+  }
+
+  const page = parseHex(token('--color-bg-primary'))
+  const cardFill = paintedCardColor('card', 'background-color')
+  const cardBorder = borderColor('card')
+  const cardHoverBorder = borderColor('card:hover')
+
+  it('paints the card border vs the page ground at >= 2:1 (house threshold, outlineVariant parity)', () => {
+    expect(contrastRatio(parseHex(cardBorder), page)).toBeGreaterThanOrEqual(2)
+  })
+
+  it('paints the card border vs the card fill at >= 2:1 (an edge must separate from both sides)', () => {
+    expect(contrastRatio(parseHex(cardBorder), parseHex(cardFill))).toBeGreaterThanOrEqual(2)
+  })
+
+  it('paints the hover border strictly brighter than the resting border (no inverted ramp)', () => {
+    expect(luminance(parseHex(cardHoverBorder))).toBeGreaterThan(luminance(parseHex(cardBorder)))
+  })
+
+  it('paints --accent-blue on the card fill at >= 4.5:1 (pins the card ground at its AA ceiling)', () => {
+    expect(contrastRatio(parseHex(token('--color-accent-blue')), parseHex(cardFill))).toBeGreaterThanOrEqual(4.5)
+  })
+
+  it('still fails the old card border values (#262626 and #333333 < 2:1 vs the page), proving the check has teeth', () => {
+    // Guards the guard: both are what a well-meaning reviewer would propose. If either ever
+    // reaches 2:1 the ratio maths has broken and the contracts above would be vacuously green.
+    expect(contrastRatio(parseHex('#262626'), page)).toBeLessThan(2)
+    expect(contrastRatio(parseHex('#333333'), page)).toBeLessThan(2)
+  })
+})
+
 describe('DESIGN.md lint', () => {
   it('reports zero errors and zero warnings', () => {
     // design.md lint exits 0 even with warnings, and CI does not run `lint:design` as its own

--- a/frontend/tests/e2e/transit.spec.ts
+++ b/frontend/tests/e2e/transit.spec.ts
@@ -159,6 +159,18 @@ test.describe('Transit App', () => {
     await expect(page.getByText('19:38')).toBeVisible()
   })
 
+  test('paints the card outline at the outdoor-legibility border (issue #96)', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.getByText('18:49')).toBeVisible()
+
+    // The card fill rises to --bg-elevated (#1a1a1a) and the outline to --border-tertiary
+    // (#666666), so the card keeps a perceivable edge under outdoor glare (ADR 0004).
+    const card = page.locator('[class*="_card_"]').first()
+    await expect(card).toBeVisible()
+    expect(await computed(card, 'background-color')).toBe('rgb(26, 26, 26)')
+    expect(await computed(card, 'border-top-color')).toBe('rgb(102, 102, 102)')
+  })
+
   test('should mark the active tab with aria-pressed', async ({ page }) => {
     await page.goto('/')
 


### PR DESCRIPTION
## Summary
Strengthens the transit card so its edge survives outdoor glare (issue #96, ADR 0004). The border now carries the card's outline: the card fill rises to `--bg-elevated` (#1a1a1a, the ADR 0004 D-4 ceiling) and the resting outline moves to a new `--border-tertiary` (#666666, 3.45:1 vs the page / 3.03:1 vs the fill). Hover moves to `--border-elevated` (#8a8a8a) so the ramp stays monotonic, and the badge drops its now-inverted fill for the same outline idiom the unselected tab uses.

## Changes
- `frontend/DESIGN.md` frontmatter: added `border-tertiary: #666666` and `border-elevated: #8a8a8a`; repointed `card` -> `{colors.bg-elevated}`, `card-border` -> `{colors.border-tertiary}`, `card-border-hover` -> `{colors.border-elevated}`; added a `badge-border` entry.
- Regenerated `frontend/src/design-tokens.css` via `npm run export:design` (generated file, not hand-edited).
- `frontend/src/index.css`: added `--border-tertiary` and `--border-elevated` aliases (`var(--color-*)`).
- `frontend/src/components/TransitCard.module.css`: `.card` -> `var(--bg-elevated)` + `1px solid var(--border-tertiary)`; `.card:hover` -> `var(--border-elevated)`; `.badge` -> transparent fill + `1px solid var(--border-tertiary)`.
- Swept the DESIGN.md prose (Colors table +2 rows, Elevation & Depth to a 4-rung border ramp, TransitCard/badge component notes).
- Added four contrast contracts + teeth/provenance guards to `frontend/tests/design-tokens.test.ts` and a computed-style assertion to the e2e suite.

## Verification
- `npm --prefix frontend test` -> exit 0, 89 passed (includes the 4 new contracts).
- `npm --prefix frontend run lint:design` -> exit 0, `"errors":0` `"warnings":0`.
- `npm --prefix frontend run lint` -> exit 0.
- `npm --prefix frontend run typecheck` -> exit 0.
- `npm --prefix frontend run build` -> exit 0.
- `npx playwright test -g "outdoor-legibility border"` -> 1 passed.
- Mutation-tested: reverting `.card` border to `--border-primary` and to `--border-secondary` both redden the 2:1 contracts; reverting `.card:hover` to `--border-secondary` reddens the monotonicity contract.

### Acceptance criteria (all MET, graded by an independent subagent)
- [x] `npm --prefix frontend test` exits 0 with the four new contracts (a) border vs page >= 2:1, (b) border vs card fill >= 2:1, (c) hover strictly brighter than resting, (d) `--accent-blue` on card fill >= 4.5:1 -- MET
- [x] `grep -qE "#262626|#333333" frontend/tests/design-tokens.test.ts` exits 0 (both asserted < 2:1 vs page) -- MET
- [x] `grep -qiE "outlineVariant|house threshold|not a WCAG" frontend/tests/design-tokens.test.ts` exits 0 -- MET
- [x] `npm --prefix frontend run lint:design` reports `"errors":0` and `"warnings":0` -- MET
- [x] `grep -q "border-tertiary"` and `grep -q "var(--bg-elevated)"` in TransitCard.module.css exit 0 -- MET
- [x] `grep -qE "#[0-9a-fA-F]{6}" frontend/src/components/TransitCard.module.css` exits 1 (no raw hex) -- MET
- [x] `lint && typecheck && build` all exit 0 -- MET

Closes #96
